### PR TITLE
[codex] harden persistence and config loading

### DIFF
--- a/Packages/com.example.gameaudiotool/Documentation~/Manual.md
+++ b/Packages/com.example.gameaudiotool/Documentation~/Manual.md
@@ -33,11 +33,18 @@ Open the tool from:
 ## Save And Load
 
 - `New` creates a fresh project shell with one default track.
-- `Open` reads `.json` project files and applies validation/fallback rules.
+- `Open` reads `.gats.json` project files and rejects broken schema or unsupported format versions.
 - `Save` writes the current project to disk.
-- `Save As` stores the project under a new file path.
+- `Save As` normalizes the selected path to the `.gats.json` session extension.
 
 The canonical session format is `.gats.json`.
+
+Config file behavior in the current foundation:
+
+- common settings: `%LocalAppData%/GameAudioTool/config.json`
+- project settings: `ProjectSettings/GameAudioToolSettings.json`
+- project settings override common defaults for sample rate, channel mode, and export directory
+- malformed config JSON falls back to built-in defaults so the editor can still open
 
 ## Samples
 

--- a/Packages/com.example.gameaudiotool/Editor/Application/GameAudioProjectFactory.cs
+++ b/Packages/com.example.gameaudiotool/Editor/Application/GameAudioProjectFactory.cs
@@ -8,6 +8,11 @@ namespace GameAudioTool.Editor.Application
     {
         public static GameAudioProject CreateDefaultProject()
         {
+            return CreateDefaultProject(GameAudioToolInfo.DefaultSampleRate, GameAudioChannelMode.Stereo);
+        }
+
+        public static GameAudioProject CreateDefaultProject(int sampleRate, GameAudioChannelMode channelMode)
+        {
             var project = new GameAudioProject
             {
                 Id = CreateId("proj"),
@@ -15,8 +20,12 @@ namespace GameAudioTool.Editor.Application
                 Bpm = GameAudioToolInfo.DefaultBpm,
                 TimeSignature = new GameAudioTimeSignature { Numerator = 4, Denominator = 4 },
                 TotalBars = GameAudioToolInfo.DefaultTotalBars,
-                SampleRate = GameAudioToolInfo.DefaultSampleRate,
-                ChannelMode = GameAudioChannelMode.Stereo,
+                SampleRate = GameAudioValidationUtility.IsSupportedSampleRate(sampleRate)
+                    ? sampleRate
+                    : GameAudioToolInfo.DefaultSampleRate,
+                ChannelMode = channelMode == GameAudioChannelMode.Mono
+                    ? GameAudioChannelMode.Mono
+                    : GameAudioChannelMode.Stereo,
                 MasterGainDb = 0.0f,
                 LoopPlayback = false
             };

--- a/Packages/com.example.gameaudiotool/Editor/Persistence/GameAudioCommonConfigSerializer.cs
+++ b/Packages/com.example.gameaudiotool/Editor/Persistence/GameAudioCommonConfigSerializer.cs
@@ -20,7 +20,14 @@ namespace GameAudioTool.Editor.Persistence
                 return new GameAudioCommonConfig();
             }
 
-            return Deserialize(File.ReadAllText(resolvedPath, Utf8WithoutBom));
+            try
+            {
+                return Deserialize(File.ReadAllText(resolvedPath, Utf8WithoutBom));
+            }
+            catch (Exception)
+            {
+                return new GameAudioCommonConfig();
+            }
         }
 
         public void Save(GameAudioCommonConfig config, string path = null)
@@ -74,7 +81,16 @@ namespace GameAudioTool.Editor.Persistence
                 return new GameAudioCommonConfig();
             }
 
-            var dto = JsonUtility.FromJson<GameAudioCommonConfigDto>(json);
+            GameAudioCommonConfigDto dto;
+            try
+            {
+                dto = JsonUtility.FromJson<GameAudioCommonConfigDto>(json);
+            }
+            catch (Exception)
+            {
+                return new GameAudioCommonConfig();
+            }
+
             if (dto == null)
             {
                 return new GameAudioCommonConfig();

--- a/Packages/com.example.gameaudiotool/Editor/Persistence/GameAudioProjectConfigSerializer.cs
+++ b/Packages/com.example.gameaudiotool/Editor/Persistence/GameAudioProjectConfigSerializer.cs
@@ -20,7 +20,14 @@ namespace GameAudioTool.Editor.Persistence
                 return new GameAudioProjectConfig();
             }
 
-            return Deserialize(File.ReadAllText(resolvedPath, Utf8WithoutBom));
+            try
+            {
+                return Deserialize(File.ReadAllText(resolvedPath, Utf8WithoutBom));
+            }
+            catch (Exception)
+            {
+                return new GameAudioProjectConfig();
+            }
         }
 
         public void Save(GameAudioProjectConfig config, string path = null)
@@ -65,7 +72,16 @@ namespace GameAudioTool.Editor.Persistence
                 return new GameAudioProjectConfig();
             }
 
-            var dto = JsonUtility.FromJson<GameAudioProjectConfigDto>(json);
+            GameAudioProjectConfigDto dto;
+            try
+            {
+                dto = JsonUtility.FromJson<GameAudioProjectConfigDto>(json);
+            }
+            catch (Exception)
+            {
+                return new GameAudioProjectConfig();
+            }
+
             if (dto == null)
             {
                 return new GameAudioProjectConfig();

--- a/Packages/com.example.gameaudiotool/Editor/Persistence/GameAudioProjectFileUtility.cs
+++ b/Packages/com.example.gameaudiotool/Editor/Persistence/GameAudioProjectFileUtility.cs
@@ -1,0 +1,47 @@
+using System;
+using System.IO;
+using GameAudioTool.Editor.Utilities;
+
+namespace GameAudioTool.Editor.Persistence
+{
+    internal static class GameAudioProjectFileUtility
+    {
+        public static string NormalizeSavePath(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new ArgumentException("A target path is required.", nameof(path));
+            }
+
+            if (HasSessionFileExtension(path))
+            {
+                return path;
+            }
+
+            string directoryPath = Path.GetDirectoryName(path);
+            string fileName = Path.GetFileNameWithoutExtension(path);
+            if (string.IsNullOrWhiteSpace(fileName))
+            {
+                fileName = "GameAudio";
+            }
+
+            return string.IsNullOrWhiteSpace(directoryPath)
+                ? $"{fileName}{GameAudioToolInfo.SessionFileExtension}"
+                : Path.Combine(directoryPath, $"{fileName}{GameAudioToolInfo.SessionFileExtension}");
+        }
+
+        public static void EnsureSessionFileExtension(string path)
+        {
+            if (!HasSessionFileExtension(path))
+            {
+                throw new GameAudioPersistenceException($"Project files must use the {GameAudioToolInfo.SessionFileExtension} extension.");
+            }
+        }
+
+        private static bool HasSessionFileExtension(string path)
+        {
+            return !string.IsNullOrWhiteSpace(path)
+                && path.EndsWith(GameAudioToolInfo.SessionFileExtension, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/Packages/com.example.gameaudiotool/Editor/Persistence/GameAudioProjectSchemaValidator.cs
+++ b/Packages/com.example.gameaudiotool/Editor/Persistence/GameAudioProjectSchemaValidator.cs
@@ -1,0 +1,544 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace GameAudioTool.Editor.Persistence
+{
+    internal static class GameAudioProjectSchemaValidator
+    {
+        public static void Validate(string json)
+        {
+            GameAudioJsonNode root = GameAudioSimpleJsonParser.Parse(json);
+            RequireObject(root, "$");
+
+            RequireString(root, "$", "formatVersion");
+            RequireString(root, "$", "toolVersion");
+
+            GameAudioJsonNode project = RequireObjectProperty(root, "$", "project");
+            ValidateProject(project, "$.project");
+        }
+
+        private static void ValidateProject(GameAudioJsonNode node, string path)
+        {
+            RequireString(node, path, "id");
+            RequireString(node, path, "name");
+            RequireNumber(node, path, "bpm");
+            GameAudioJsonNode timeSignature = RequireObjectProperty(node, path, "timeSignature");
+            RequireNumber(timeSignature, $"{path}.timeSignature", "numerator");
+            RequireNumber(timeSignature, $"{path}.timeSignature", "denominator");
+            RequireNumber(node, path, "totalBars");
+            RequireNumber(node, path, "sampleRate");
+            RequireString(node, path, "channelMode");
+            RequireNumber(node, path, "masterGainDb");
+            RequireBoolean(node, path, "loopPlayback");
+
+            GameAudioJsonNode tracks = RequireArrayProperty(node, path, "tracks");
+            for (int index = 0; index < tracks.Items.Count; index++)
+            {
+                ValidateTrack(tracks.Items[index], $"{path}.tracks[{index}]");
+            }
+        }
+
+        private static void ValidateTrack(GameAudioJsonNode node, string path)
+        {
+            RequireObject(node, path);
+            RequireString(node, path, "id");
+            RequireString(node, path, "name");
+            RequireBoolean(node, path, "mute");
+            RequireBoolean(node, path, "solo");
+            RequireNumber(node, path, "volumeDb");
+            RequireNumber(node, path, "pan");
+            ValidateVoice(RequireObjectProperty(node, path, "defaultVoice"), $"{path}.defaultVoice");
+
+            GameAudioJsonNode notes = RequireArrayProperty(node, path, "notes");
+            for (int index = 0; index < notes.Items.Count; index++)
+            {
+                ValidateNote(notes.Items[index], $"{path}.notes[{index}]");
+            }
+        }
+
+        private static void ValidateNote(GameAudioJsonNode node, string path)
+        {
+            RequireObject(node, path);
+            RequireString(node, path, "id");
+            RequireNumber(node, path, "startBeat");
+            RequireNumber(node, path, "durationBeat");
+            RequireNumber(node, path, "midiNote");
+            RequireNumber(node, path, "velocity");
+
+            if (TryGetProperty(node, "voiceOverride", out GameAudioJsonNode voiceOverride) && voiceOverride.Kind != GameAudioJsonKind.Null)
+            {
+                ValidateVoice(voiceOverride, $"{path}.voiceOverride");
+            }
+        }
+
+        private static void ValidateVoice(GameAudioJsonNode node, string path)
+        {
+            RequireObject(node, path);
+            RequireString(node, path, "waveform");
+            RequireNumber(node, path, "pulseWidth");
+            RequireBoolean(node, path, "noiseEnabled");
+            RequireString(node, path, "noiseType");
+            RequireNumber(node, path, "noiseMix");
+            ValidateEnvelope(RequireObjectProperty(node, path, "adsr"), $"{path}.adsr");
+            ValidateEffect(RequireObjectProperty(node, path, "effect"), $"{path}.effect");
+        }
+
+        private static void ValidateEnvelope(GameAudioJsonNode node, string path)
+        {
+            RequireObject(node, path);
+            RequireNumber(node, path, "attackMs");
+            RequireNumber(node, path, "decayMs");
+            RequireNumber(node, path, "sustain");
+            RequireNumber(node, path, "releaseMs");
+        }
+
+        private static void ValidateEffect(GameAudioJsonNode node, string path)
+        {
+            RequireObject(node, path);
+            RequireNumber(node, path, "volumeDb");
+            RequireNumber(node, path, "pan");
+            RequireNumber(node, path, "pitchSemitone");
+            RequireNumber(node, path, "fadeInMs");
+            RequireNumber(node, path, "fadeOutMs");
+            ValidateDelay(RequireObjectProperty(node, path, "delay"), $"{path}.delay");
+        }
+
+        private static void ValidateDelay(GameAudioJsonNode node, string path)
+        {
+            RequireObject(node, path);
+            RequireBoolean(node, path, "enabled");
+            RequireNumber(node, path, "timeMs");
+            RequireNumber(node, path, "feedback");
+            RequireNumber(node, path, "mix");
+        }
+
+        private static void RequireObject(GameAudioJsonNode node, string path)
+        {
+            if (node == null || node.Kind != GameAudioJsonKind.Object)
+            {
+                throw new GameAudioPersistenceException($"{path} must be an object.");
+            }
+        }
+
+        private static void RequireString(GameAudioJsonNode node, string path, string propertyName)
+        {
+            RequirePropertyKind(node, path, propertyName, GameAudioJsonKind.String);
+        }
+
+        private static void RequireNumber(GameAudioJsonNode node, string path, string propertyName)
+        {
+            RequirePropertyKind(node, path, propertyName, GameAudioJsonKind.Number);
+        }
+
+        private static void RequireBoolean(GameAudioJsonNode node, string path, string propertyName)
+        {
+            RequirePropertyKind(node, path, propertyName, GameAudioJsonKind.Boolean);
+        }
+
+        private static GameAudioJsonNode RequireObjectProperty(GameAudioJsonNode node, string path, string propertyName)
+        {
+            return RequirePropertyKind(node, path, propertyName, GameAudioJsonKind.Object);
+        }
+
+        private static GameAudioJsonNode RequireArrayProperty(GameAudioJsonNode node, string path, string propertyName)
+        {
+            return RequirePropertyKind(node, path, propertyName, GameAudioJsonKind.Array);
+        }
+
+        private static GameAudioJsonNode RequirePropertyKind(GameAudioJsonNode node, string path, string propertyName, GameAudioJsonKind expectedKind)
+        {
+            if (!TryGetProperty(node, propertyName, out GameAudioJsonNode propertyValue))
+            {
+                throw new GameAudioPersistenceException($"{path}.{propertyName} is required.");
+            }
+
+            if (propertyValue.Kind != expectedKind)
+            {
+                throw new GameAudioPersistenceException($"{path}.{propertyName} must be a {expectedKind.ToString().ToLowerInvariant()}.");
+            }
+
+            return propertyValue;
+        }
+
+        private static bool TryGetProperty(GameAudioJsonNode node, string propertyName, out GameAudioJsonNode propertyValue)
+        {
+            propertyValue = null;
+            return node != null
+                && node.Kind == GameAudioJsonKind.Object
+                && node.TryGetProperty(propertyName, out propertyValue);
+        }
+    }
+
+    internal enum GameAudioJsonKind
+    {
+        Object,
+        Array,
+        String,
+        Number,
+        Boolean,
+        Null
+    }
+
+    internal sealed class GameAudioJsonNode
+    {
+        private readonly Dictionary<string, GameAudioJsonNode> _properties;
+        private readonly List<GameAudioJsonNode> _items;
+
+        private GameAudioJsonNode(GameAudioJsonKind kind, Dictionary<string, GameAudioJsonNode> properties = null, List<GameAudioJsonNode> items = null)
+        {
+            Kind = kind;
+            _properties = properties;
+            _items = items;
+        }
+
+        public GameAudioJsonKind Kind { get; }
+
+        public IReadOnlyList<GameAudioJsonNode> Items => _items ?? (IReadOnlyList<GameAudioJsonNode>)Array.Empty<GameAudioJsonNode>();
+
+        public static GameAudioJsonNode Object(Dictionary<string, GameAudioJsonNode> properties)
+        {
+            return new GameAudioJsonNode(GameAudioJsonKind.Object, properties: properties);
+        }
+
+        public static GameAudioJsonNode Array(List<GameAudioJsonNode> items)
+        {
+            return new GameAudioJsonNode(GameAudioJsonKind.Array, items: items);
+        }
+
+        public static GameAudioJsonNode String()
+        {
+            return new GameAudioJsonNode(GameAudioJsonKind.String);
+        }
+
+        public static GameAudioJsonNode Number()
+        {
+            return new GameAudioJsonNode(GameAudioJsonKind.Number);
+        }
+
+        public static GameAudioJsonNode Boolean()
+        {
+            return new GameAudioJsonNode(GameAudioJsonKind.Boolean);
+        }
+
+        public static GameAudioJsonNode Null()
+        {
+            return new GameAudioJsonNode(GameAudioJsonKind.Null);
+        }
+
+        public bool TryGetProperty(string name, out GameAudioJsonNode value)
+        {
+            value = null;
+            return _properties != null && _properties.TryGetValue(name, out value);
+        }
+    }
+
+    internal sealed class GameAudioSimpleJsonParser
+    {
+        private readonly string _json;
+        private int _index;
+
+        private GameAudioSimpleJsonParser(string json)
+        {
+            _json = json ?? string.Empty;
+        }
+
+        public static GameAudioJsonNode Parse(string json)
+        {
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                throw new GameAudioPersistenceException("Project JSON is empty.");
+            }
+
+            var parser = new GameAudioSimpleJsonParser(json);
+            GameAudioJsonNode value = parser.ParseValue();
+            parser.SkipWhitespace();
+            if (!parser.IsEnd)
+            {
+                parser.Fail("Unexpected trailing characters.");
+            }
+
+            return value;
+        }
+
+        private bool IsEnd => _index >= _json.Length;
+
+        private GameAudioJsonNode ParseValue()
+        {
+            SkipWhitespace();
+            if (IsEnd)
+            {
+                Fail("Unexpected end of input.");
+            }
+
+            switch (_json[_index])
+            {
+                case '{':
+                    return ParseObject();
+                case '[':
+                    return ParseArray();
+                case '"':
+                    ParseStringValue();
+                    return GameAudioJsonNode.String();
+                case 't':
+                    ParseLiteral("true");
+                    return GameAudioJsonNode.Boolean();
+                case 'f':
+                    ParseLiteral("false");
+                    return GameAudioJsonNode.Boolean();
+                case 'n':
+                    ParseLiteral("null");
+                    return GameAudioJsonNode.Null();
+                default:
+                    if (_json[_index] == '-' || char.IsDigit(_json[_index]))
+                    {
+                        ParseNumberValue();
+                        return GameAudioJsonNode.Number();
+                    }
+
+                    Fail($"Unexpected character '{_json[_index]}'.");
+                    return null;
+            }
+        }
+
+        private GameAudioJsonNode ParseObject()
+        {
+            Expect('{');
+            SkipWhitespace();
+
+            var properties = new Dictionary<string, GameAudioJsonNode>(StringComparer.Ordinal);
+            if (TryConsume('}'))
+            {
+                return GameAudioJsonNode.Object(properties);
+            }
+
+            while (true)
+            {
+                SkipWhitespace();
+                if (Current != '"')
+                {
+                    Fail("Object keys must be strings.");
+                }
+
+                string propertyName = ParseStringValue();
+                SkipWhitespace();
+                Expect(':');
+                GameAudioJsonNode propertyValue = ParseValue();
+                properties[propertyName] = propertyValue;
+
+                SkipWhitespace();
+                if (TryConsume('}'))
+                {
+                    return GameAudioJsonNode.Object(properties);
+                }
+
+                Expect(',');
+            }
+        }
+
+        private GameAudioJsonNode ParseArray()
+        {
+            Expect('[');
+            SkipWhitespace();
+
+            var items = new List<GameAudioJsonNode>();
+            if (TryConsume(']'))
+            {
+                return GameAudioJsonNode.Array(items);
+            }
+
+            while (true)
+            {
+                items.Add(ParseValue());
+                SkipWhitespace();
+                if (TryConsume(']'))
+                {
+                    return GameAudioJsonNode.Array(items);
+                }
+
+                Expect(',');
+            }
+        }
+
+        private string ParseStringValue()
+        {
+            Expect('"');
+
+            var builder = new StringBuilder();
+            while (!IsEnd)
+            {
+                char character = _json[_index++];
+                if (character == '"')
+                {
+                    return builder.ToString();
+                }
+
+                if (character == '\\')
+                {
+                    if (IsEnd)
+                    {
+                        Fail("Unterminated escape sequence.");
+                    }
+
+                    builder.Append(ParseEscapedCharacter());
+                    continue;
+                }
+
+                if (character < 0x20)
+                {
+                    Fail("Control characters must be escaped.");
+                }
+
+                builder.Append(character);
+            }
+
+            Fail("Unterminated string literal.");
+            return string.Empty;
+        }
+
+        private char ParseEscapedCharacter()
+        {
+            char escape = _json[_index++];
+            switch (escape)
+            {
+                case '"':
+                case '\\':
+                case '/':
+                    return escape;
+                case 'b':
+                    return '\b';
+                case 'f':
+                    return '\f';
+                case 'n':
+                    return '\n';
+                case 'r':
+                    return '\r';
+                case 't':
+                    return '\t';
+                case 'u':
+                    return ParseUnicodeEscape();
+                default:
+                    Fail($"Unsupported escape sequence '\\{escape}'.");
+                    return '\0';
+            }
+        }
+
+        private char ParseUnicodeEscape()
+        {
+            if (_index + 4 > _json.Length)
+            {
+                Fail("Incomplete unicode escape.");
+            }
+
+            string hex = _json.Substring(_index, 4);
+            if (!ushort.TryParse(hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out ushort codePoint))
+            {
+                Fail("Invalid unicode escape.");
+            }
+
+            _index += 4;
+            return (char)codePoint;
+        }
+
+        private void ParseNumberValue()
+        {
+            int start = _index;
+
+            if (Current == '-')
+            {
+                _index++;
+            }
+
+            ConsumeDigits(requireAtLeastOneDigit: true);
+
+            if (!IsEnd && Current == '.')
+            {
+                _index++;
+                ConsumeDigits(requireAtLeastOneDigit: true);
+            }
+
+            if (!IsEnd && (Current == 'e' || Current == 'E'))
+            {
+                _index++;
+                if (!IsEnd && (Current == '+' || Current == '-'))
+                {
+                    _index++;
+                }
+
+                ConsumeDigits(requireAtLeastOneDigit: true);
+            }
+
+            string value = _json.Substring(start, _index - start);
+            if (!double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out _))
+            {
+                Fail($"Invalid number '{value}'.");
+            }
+        }
+
+        private void ConsumeDigits(bool requireAtLeastOneDigit)
+        {
+            int start = _index;
+            while (!IsEnd && char.IsDigit(Current))
+            {
+                _index++;
+            }
+
+            if (requireAtLeastOneDigit && start == _index)
+            {
+                Fail("Expected a digit.");
+            }
+        }
+
+        private void ParseLiteral(string literal)
+        {
+            for (int literalIndex = 0; literalIndex < literal.Length; literalIndex++)
+            {
+                if (IsEnd || _json[_index] != literal[literalIndex])
+                {
+                    Fail($"Expected '{literal}'.");
+                }
+
+                _index++;
+            }
+        }
+
+        private void Expect(char expectedCharacter)
+        {
+            SkipWhitespace();
+            if (IsEnd || _json[_index] != expectedCharacter)
+            {
+                Fail($"Expected '{expectedCharacter}'.");
+            }
+
+            _index++;
+        }
+
+        private bool TryConsume(char expectedCharacter)
+        {
+            SkipWhitespace();
+            if (IsEnd || _json[_index] != expectedCharacter)
+            {
+                return false;
+            }
+
+            _index++;
+            return true;
+        }
+
+        private char Current => _json[_index];
+
+        private void SkipWhitespace()
+        {
+            while (!IsEnd && char.IsWhiteSpace(_json[_index]))
+            {
+                _index++;
+            }
+        }
+
+        private void Fail(string message)
+        {
+            throw new GameAudioPersistenceException($"Failed to parse project JSON at index {_index}: {message}");
+        }
+    }
+}

--- a/Packages/com.example.gameaudiotool/Editor/Persistence/GameAudioProjectSerializer.cs
+++ b/Packages/com.example.gameaudiotool/Editor/Persistence/GameAudioProjectSerializer.cs
@@ -33,18 +33,15 @@ namespace GameAudioTool.Editor.Persistence
 
         public void SaveToFile(string path, GameAudioProject project)
         {
-            if (string.IsNullOrWhiteSpace(path))
-            {
-                throw new ArgumentException("A target path is required.", nameof(path));
-            }
+            string resolvedPath = GameAudioProjectFileUtility.NormalizeSavePath(path);
 
-            string directoryPath = Path.GetDirectoryName(path);
+            string directoryPath = Path.GetDirectoryName(resolvedPath);
             if (!string.IsNullOrWhiteSpace(directoryPath))
             {
                 Directory.CreateDirectory(directoryPath);
             }
 
-            File.WriteAllText(path, Serialize(project), Utf8WithoutBom);
+            File.WriteAllText(resolvedPath, Serialize(project), Utf8WithoutBom);
         }
 
         public GameAudioProjectLoadResult LoadFromFile(string path)
@@ -53,6 +50,8 @@ namespace GameAudioTool.Editor.Persistence
             {
                 throw new ArgumentException("A source path is required.", nameof(path));
             }
+
+            GameAudioProjectFileUtility.EnsureSessionFileExtension(path);
 
             if (!File.Exists(path))
             {
@@ -69,6 +68,8 @@ namespace GameAudioTool.Editor.Persistence
             {
                 throw new GameAudioPersistenceException("Project JSON is empty.");
             }
+
+            GameAudioProjectSchemaValidator.Validate(json);
 
             GameAudioProjectFileDto rootDto;
             try

--- a/Packages/com.example.gameaudiotool/Editor/Windows/GameAudioToolWindow.cs
+++ b/Packages/com.example.gameaudiotool/Editor/Windows/GameAudioToolWindow.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using GameAudioTool.Editor.Application;
+using GameAudioTool.Editor.Config;
 using GameAudioTool.Editor.Domain;
 using GameAudioTool.Editor.Persistence;
 using GameAudioTool.Editor.Utilities;
@@ -12,7 +13,9 @@ namespace GameAudioTool.Editor.Windows
 {
     public sealed class GameAudioToolWindow : EditorWindow
     {
+        private readonly GameAudioCommonConfigSerializer _commonConfigSerializer = new GameAudioCommonConfigSerializer();
         private readonly GameAudioProjectSerializer _projectSerializer = new GameAudioProjectSerializer();
+        private readonly GameAudioProjectConfigSerializer _projectConfigSerializer = new GameAudioProjectConfigSerializer();
 
         private GameAudioProject _project;
         private string _projectPath = string.Empty;
@@ -40,7 +43,7 @@ namespace GameAudioTool.Editor.Windows
         {
             if (_project == null)
             {
-                _project = GameAudioProjectFactory.CreateDefaultProject();
+                _project = CreateConfiguredProject();
                 _isDirty = true;
             }
 
@@ -171,7 +174,7 @@ namespace GameAudioTool.Editor.Windows
                 return;
             }
 
-            _project = GameAudioProjectFactory.CreateDefaultProject();
+            _project = CreateConfiguredProject();
             _projectPath = string.Empty;
             _isDirty = true;
             _loadWarnings.Clear();
@@ -240,8 +243,9 @@ namespace GameAudioTool.Editor.Windows
         {
             try
             {
-                _projectSerializer.SaveToFile(targetPath, _project);
-                _projectPath = targetPath;
+                string resolvedPath = GameAudioProjectFileUtility.NormalizeSavePath(targetPath);
+                _projectSerializer.SaveToFile(resolvedPath, _project);
+                _projectPath = resolvedPath;
                 _isDirty = false;
                 ShowNotification(new GUIContent("Project saved."));
                 RefreshView();
@@ -278,6 +282,15 @@ namespace GameAudioTool.Editor.Windows
             }
 
             return false;
+        }
+
+        private GameAudioProject CreateConfiguredProject()
+        {
+            GameAudioCommonConfig commonConfig = _commonConfigSerializer.LoadOrDefault();
+            GameAudioProjectConfig projectConfig = _projectConfigSerializer.LoadOrDefault();
+            int sampleRate = GameAudioConfigResolver.ResolveSampleRate(commonConfig, projectConfig);
+            GameAudioChannelMode channelMode = GameAudioConfigResolver.ResolveChannelMode(commonConfig, projectConfig);
+            return GameAudioProjectFactory.CreateDefaultProject(sampleRate, channelMode);
         }
 
         private void RefreshView()

--- a/Packages/com.example.gameaudiotool/Tests/Editor/GameAudioConfigSerializerTests.cs
+++ b/Packages/com.example.gameaudiotool/Tests/Editor/GameAudioConfigSerializerTests.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using NUnit.Framework;
+using GameAudioTool.Editor.Application;
 using GameAudioTool.Editor.Config;
 using GameAudioTool.Editor.Domain;
 using GameAudioTool.Editor.Persistence;
@@ -105,6 +106,79 @@ namespace GameAudioTool.Editor.Tests
                     Directory.Delete(root, true);
                 }
             }
+        }
+
+        [Test]
+        public void CommonConfigSerializer_LoadOrDefault_ReturnsDefaultsForInvalidJson()
+        {
+            var serializer = new GameAudioCommonConfigSerializer();
+            string root = Path.Combine(Path.GetTempPath(), "GameAudioToolTests", Path.GetRandomFileName());
+            string configPath = Path.Combine(root, "config.json");
+
+            try
+            {
+                Directory.CreateDirectory(root);
+                File.WriteAllText(configPath, "{ invalid json");
+
+                GameAudioCommonConfig result = serializer.LoadOrDefault(configPath);
+
+                Assert.That(result.DefaultSampleRate, Is.EqualTo(48000));
+                Assert.That(result.DefaultChannelMode, Is.EqualTo(GameAudioChannelMode.Stereo));
+                Assert.That(result.UndoHistoryLimit, Is.EqualTo(100));
+            }
+            finally
+            {
+                if (Directory.Exists(root))
+                {
+                    Directory.Delete(root, true);
+                }
+            }
+        }
+
+        [Test]
+        public void ProjectConfigSerializer_LoadOrDefault_ReturnsDefaultsForInvalidJson()
+        {
+            var serializer = new GameAudioProjectConfigSerializer();
+            string root = Path.Combine(Path.GetTempPath(), "GameAudioToolTests", Path.GetRandomFileName());
+            string configPath = Path.Combine(root, "config.json");
+
+            try
+            {
+                Directory.CreateDirectory(root);
+                File.WriteAllText(configPath, "{ invalid json");
+
+                GameAudioProjectConfig result = serializer.LoadOrDefault(configPath);
+
+                Assert.That(result.ExportDirectory, Is.EqualTo(string.Empty));
+                Assert.That(result.AutoRefreshAfterExport, Is.True);
+                Assert.That(result.PreferredSampleRate, Is.Null);
+                Assert.That(result.PreferredChannelMode, Is.Null);
+            }
+            finally
+            {
+                if (Directory.Exists(root))
+                {
+                    Directory.Delete(root, true);
+                }
+            }
+        }
+
+        [Test]
+        public void ProjectFactory_UsesResolvedConfigDefaults()
+        {
+            var commonConfig = new GameAudioCommonConfig
+            {
+                DefaultSampleRate = 44100,
+                DefaultChannelMode = GameAudioChannelMode.Mono
+            };
+
+            var projectConfig = new GameAudioProjectConfig();
+            GameAudioProject project = GameAudioProjectFactory.CreateDefaultProject(
+                GameAudioConfigResolver.ResolveSampleRate(commonConfig, projectConfig),
+                GameAudioConfigResolver.ResolveChannelMode(commonConfig, projectConfig));
+
+            Assert.That(project.SampleRate, Is.EqualTo(44100));
+            Assert.That(project.ChannelMode, Is.EqualTo(GameAudioChannelMode.Mono));
         }
     }
 }

--- a/Packages/com.example.gameaudiotool/Tests/Editor/GameAudioProjectSerializerTests.cs
+++ b/Packages/com.example.gameaudiotool/Tests/Editor/GameAudioProjectSerializerTests.cs
@@ -2,6 +2,8 @@ using NUnit.Framework;
 using GameAudioTool.Editor.Application;
 using GameAudioTool.Editor.Domain;
 using GameAudioTool.Editor.Persistence;
+using GameAudioTool.Editor.Utilities;
+using System.IO;
 
 namespace GameAudioTool.Editor.Tests
 {
@@ -60,6 +62,30 @@ namespace GameAudioTool.Editor.Tests
             var serializer = new GameAudioProjectSerializer();
 
             Assert.Throws<GameAudioPersistenceException>(() => serializer.Deserialize(json));
+        }
+
+        [Test]
+        public void Deserialize_RejectsMissingRequiredField()
+        {
+            const string json = @"{
+  ""formatVersion"": ""1.0.0"",
+  ""toolVersion"": ""0.1.0"",
+  ""project"": {
+    ""id"": ""proj-001"",
+    ""bpm"": 120,
+    ""timeSignature"": { ""numerator"": 4, ""denominator"": 4 },
+    ""totalBars"": 4,
+    ""sampleRate"": 48000,
+    ""channelMode"": ""Stereo"",
+    ""masterGainDb"": 0.0,
+    ""loopPlayback"": false,
+    ""tracks"": []
+  }
+}";
+
+            var serializer = new GameAudioProjectSerializer();
+            GameAudioPersistenceException exception = Assert.Throws<GameAudioPersistenceException>(() => serializer.Deserialize(json));
+            StringAssert.Contains("$.project.name is required.", exception.Message);
         }
 
         [Test]
@@ -179,6 +205,39 @@ namespace GameAudioTool.Editor.Tests
 
             var serializer = new GameAudioProjectSerializer();
             Assert.Throws<GameAudioPersistenceException>(() => serializer.Deserialize(json));
+        }
+
+        [Test]
+        public void SaveToFile_NormalizesSessionFileExtension()
+        {
+            var serializer = new GameAudioProjectSerializer();
+            GameAudioProject project = GameAudioProjectFactory.CreateDefaultProject();
+            string root = Path.Combine(Path.GetTempPath(), "GameAudioToolTests", Path.GetRandomFileName());
+            string targetPath = Path.Combine(root, "session");
+            string expectedPath = $"{targetPath}{GameAudioToolInfo.SessionFileExtension}";
+
+            try
+            {
+                serializer.SaveToFile(targetPath, project);
+                Assert.That(File.Exists(expectedPath), Is.True);
+            }
+            finally
+            {
+                if (Directory.Exists(root))
+                {
+                    Directory.Delete(root, true);
+                }
+            }
+        }
+
+        [Test]
+        public void LoadFromFile_RejectsNonSessionFileExtension()
+        {
+            var serializer = new GameAudioProjectSerializer();
+            string path = Path.Combine(Path.GetTempPath(), "project.json");
+
+            GameAudioPersistenceException exception = Assert.Throws<GameAudioPersistenceException>(() => serializer.LoadFromFile(path));
+            StringAssert.Contains(GameAudioToolInfo.SessionFileExtension, exception.Message);
         }
     }
 }


### PR DESCRIPTION
## Summary
- enforce the canonical `.gats.json` session extension on save/load flows
- add a strict schema validator for required `.gats.json` fields before DTO deserialization
- fall back to built-in defaults when common or project config JSON is malformed
- apply resolved common/project config defaults when creating a new project shell
- expand editor tests and manual notes around persistence and config behavior

## Validation
- verified sample session JSON syntax for `basic-se.gats.json` and `simple-loop.gats.json`
- added serializer/config tests for missing required fields, invalid config JSON, and session path normalization
- Unity Editor compilation and Test Runner execution were not run in this environment

Closes #2