### PR TITLE
[codex] add editor preview playback

### DIFF
--- a/Packages/com.example.gameaudiotool/CHANGELOG.md
+++ b/Packages/com.example.gameaudiotool/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - added a deterministic offline render core for waveform, noise, ADSR, delay, and track/project mixdown
 - added renderer-focused editor tests for determinism, waveform coverage, tail extension, and unsafe parameter clamping
+- added Unity Editor preview transport controls with Play, Stop, Rewind, loop playback, and cursor reporting
 
 ## 0.1.0
 

--- a/Packages/com.example.gameaudiotool/Documentation~/Manual.md
+++ b/Packages/com.example.gameaudiotool/Documentation~/Manual.md
@@ -10,12 +10,12 @@ Current implementation scope:
 - create a new project shell
 - save and load `.gats.json` project files
 - render project data into deterministic offline audio buffers
+- preview those buffers in the Unity Editor with Play / Stop / Rewind / Loop transport controls
 - keep package samples and configuration foundations in place
 
 Not implemented yet in this package revision:
 
 - timeline note editing UI
-- audio preview playback
 - WAV export
 - Undo / Redo command history
 
@@ -39,6 +39,14 @@ Open the tool from:
 - `Save As` normalizes the selected path to the `.gats.json` session extension.
 
 The canonical session format is `.gats.json`.
+
+## Preview Playback
+
+- `Render Preview` builds the current project into an `AudioClip`-backed editor preview buffer.
+- `Play` starts preview playback from the beginning.
+- `Stop` stops playback and returns the cursor to the start.
+- `Rewind` resets the cursor without rebuilding the preview buffer.
+- `Loop` is stored on the project and uses `Total Bars` as the loop length while one-shot playback still includes rendered effect tails.
 
 Config file behavior in the current foundation:
 

--- a/Packages/com.example.gameaudiotool/Editor/AssemblyInfo.cs
+++ b/Packages/com.example.gameaudiotool/Editor/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("GameAudioTool.Editor.Tests")]

--- a/Packages/com.example.gameaudiotool/Editor/Audio/GameAudioEditorAudioUtility.cs
+++ b/Packages/com.example.gameaudiotool/Editor/Audio/GameAudioEditorAudioUtility.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using UnityEditor;
+using UnityEngine;
+
+namespace GameAudioTool.Editor.Audio
+{
+    internal static class GameAudioEditorAudioUtility
+    {
+        private static readonly Type AudioUtilType = typeof(AudioImporter).Assembly.GetType("UnityEditor.AudioUtil");
+        private static readonly MethodInfo PlayPreviewClipMethod = ResolveMethod(
+            "PlayPreviewClip",
+            "PlayClip");
+        private static readonly MethodInfo StopPreviewClipMethod = ResolveStopMethod(
+            "StopPreviewClip",
+            "StopClip");
+        private static readonly MethodInfo StopAllPreviewClipsMethod = ResolveParameterlessMethod(
+            "StopAllPreviewClips",
+            "StopAllClips");
+
+        public static bool IsAvailable => AudioUtilType != null
+            && PlayPreviewClipMethod != null
+            && (StopPreviewClipMethod != null || StopAllPreviewClipsMethod != null);
+
+        public static bool SupportsNativeLooping => PlayPreviewClipMethod != null
+            && PlayPreviewClipMethod.GetParameters().Any(parameter => parameter.ParameterType == typeof(bool));
+
+        public static void PlayPreviewClip(AudioClip clip, bool loopPlayback)
+        {
+            if (clip == null)
+            {
+                throw new ArgumentNullException(nameof(clip));
+            }
+
+            if (!IsAvailable)
+            {
+                throw new InvalidOperationException("UnityEditor preview audio API is unavailable in this editor build.");
+            }
+
+            object[] arguments = BuildPlayArguments(PlayPreviewClipMethod, clip, loopPlayback);
+            PlayPreviewClipMethod.Invoke(null, arguments);
+        }
+
+        public static void StopPreviewClip(AudioClip clip)
+        {
+            if (!IsAvailable)
+            {
+                return;
+            }
+
+            if (clip != null && StopPreviewClipMethod != null)
+            {
+                StopPreviewClipMethod.Invoke(null, new object[] { clip });
+                return;
+            }
+
+            StopAllPreviewClips();
+        }
+
+        public static void StopAllPreviewClips()
+        {
+            if (!IsAvailable || StopAllPreviewClipsMethod == null)
+            {
+                return;
+            }
+
+            StopAllPreviewClipsMethod.Invoke(null, null);
+        }
+
+        private static MethodInfo ResolveMethod(params string[] names)
+        {
+            if (AudioUtilType == null)
+            {
+                return null;
+            }
+
+            foreach (string name in names)
+            {
+                MethodInfo match = AudioUtilType
+                    .GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+                    .Where(method => method.Name == name)
+                    .OrderByDescending(method => method.GetParameters().Length)
+                    .FirstOrDefault(IsSupportedPlayMethod);
+                if (match != null)
+                {
+                    return match;
+                }
+            }
+
+            return null;
+        }
+
+        private static MethodInfo ResolveStopMethod(params string[] names)
+        {
+            if (AudioUtilType == null)
+            {
+                return null;
+            }
+
+            foreach (string name in names)
+            {
+                MethodInfo match = AudioUtilType
+                    .GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+                    .FirstOrDefault(method =>
+                    {
+                        ParameterInfo[] parameters = method.GetParameters();
+                        return method.Name == name
+                            && parameters.Length == 1
+                            && parameters[0].ParameterType == typeof(AudioClip);
+                    });
+
+                if (match != null)
+                {
+                    return match;
+                }
+            }
+
+            return null;
+        }
+
+        private static MethodInfo ResolveParameterlessMethod(params string[] names)
+        {
+            if (AudioUtilType == null)
+            {
+                return null;
+            }
+
+            foreach (string name in names)
+            {
+                MethodInfo match = AudioUtilType
+                    .GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+                    .FirstOrDefault(method => method.Name == name && method.GetParameters().Length == 0);
+                if (match != null)
+                {
+                    return match;
+                }
+            }
+
+            return null;
+        }
+
+        private static bool IsSupportedPlayMethod(MethodInfo method)
+        {
+            ParameterInfo[] parameters = method.GetParameters();
+            if (parameters.Length == 0 || parameters[0].ParameterType != typeof(AudioClip))
+            {
+                return false;
+            }
+
+            for (int index = 1; index < parameters.Length; index++)
+            {
+                Type parameterType = parameters[index].ParameterType;
+                if (parameterType != typeof(int) && parameterType != typeof(bool))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static object[] BuildPlayArguments(MethodInfo method, AudioClip clip, bool loopPlayback)
+        {
+            ParameterInfo[] parameters = method.GetParameters();
+            object[] arguments = new object[parameters.Length];
+            arguments[0] = clip;
+
+            for (int index = 1; index < parameters.Length; index++)
+            {
+                Type parameterType = parameters[index].ParameterType;
+                if (parameterType == typeof(bool))
+                {
+                    arguments[index] = loopPlayback;
+                }
+                else if (parameterType == typeof(int))
+                {
+                    arguments[index] = 0;
+                }
+                else
+                {
+                    arguments[index] = parameterType.IsValueType
+                        ? Activator.CreateInstance(parameterType)
+                        : null;
+                }
+            }
+
+            return arguments;
+        }
+    }
+}

--- a/Packages/com.example.gameaudiotool/Editor/Audio/GameAudioPreviewCursorCalculator.cs
+++ b/Packages/com.example.gameaudiotool/Editor/Audio/GameAudioPreviewCursorCalculator.cs
@@ -1,0 +1,95 @@
+using System;
+using GameAudioTool.Editor.Domain;
+
+namespace GameAudioTool.Editor.Audio
+{
+    public static class GameAudioPreviewCursorCalculator
+    {
+        public static GameAudioPreviewCursorState Calculate(GameAudioProject project, GameAudioPreviewState previewState)
+        {
+            if (project == null || previewState?.RenderResult == null || previewState.SampleRate <= 0)
+            {
+                return new GameAudioPreviewCursorState(0.0d, 0.0f, 1, 1.0d, false, 0.0d);
+            }
+
+            double projectDurationSeconds = Math.Max(0.0d, previewState.ProjectDurationSeconds);
+            double outputDurationSeconds = Math.Max(projectDurationSeconds, previewState.OutputDurationSeconds);
+            double playbackSeconds = Clamp(previewState.PlaybackSeconds, 0.0d, outputDurationSeconds);
+            double musicalSeconds = Math.Min(projectDurationSeconds, playbackSeconds);
+            bool isInTail = !previewState.LoopPlayback && playbackSeconds > projectDurationSeconds;
+            double tailSeconds = Math.Max(0.0d, playbackSeconds - projectDurationSeconds);
+            float musicalProgress = projectDurationSeconds <= 0.0d
+                ? 0.0f
+                : (float)(musicalSeconds / projectDurationSeconds);
+
+            double secondsPerBeat = 60.0d / Math.Max(1, project.Bpm);
+            double beatsPerBar = GetBeatsPerBar(project.TimeSignature);
+            int totalBars = Math.Max(1, project.TotalBars);
+            double totalBeats = Math.Max(beatsPerBar, totalBars * beatsPerBar);
+            double currentBeatPosition = secondsPerBeat <= 0.0d
+                ? 0.0d
+                : Math.Min(totalBeats, musicalSeconds / secondsPerBeat);
+
+            if (currentBeatPosition >= totalBeats)
+            {
+                return new GameAudioPreviewCursorState(
+                    musicalSeconds,
+                    Clamp(musicalProgress, 0.0f, 1.0f),
+                    totalBars,
+                    beatsPerBar,
+                    isInTail,
+                    tailSeconds);
+            }
+
+            int zeroBasedBar = Math.Min(totalBars - 1, (int)Math.Floor(currentBeatPosition / beatsPerBar));
+            double beatInBar = (currentBeatPosition - (zeroBasedBar * beatsPerBar)) + 1.0d;
+            return new GameAudioPreviewCursorState(
+                musicalSeconds,
+                Clamp(musicalProgress, 0.0f, 1.0f),
+                zeroBasedBar + 1,
+                beatInBar,
+                isInTail,
+                tailSeconds);
+        }
+
+        private static double GetBeatsPerBar(GameAudioTimeSignature timeSignature)
+        {
+            if (timeSignature == null || timeSignature.Denominator <= 0)
+            {
+                return 4.0d;
+            }
+
+            return Math.Max(1.0d, timeSignature.Numerator * (4.0d / timeSignature.Denominator));
+        }
+
+        private static double Clamp(double value, double min, double max)
+        {
+            if (value < min)
+            {
+                return min;
+            }
+
+            if (value > max)
+            {
+                return max;
+            }
+
+            return value;
+        }
+
+        private static float Clamp(float value, float min, float max)
+        {
+            if (value < min)
+            {
+                return min;
+            }
+
+            if (value > max)
+            {
+                return max;
+            }
+
+            return value;
+        }
+    }
+}

--- a/Packages/com.example.gameaudiotool/Editor/Audio/GameAudioPreviewCursorState.cs
+++ b/Packages/com.example.gameaudiotool/Editor/Audio/GameAudioPreviewCursorState.cs
@@ -1,0 +1,33 @@
+namespace GameAudioTool.Editor.Audio
+{
+    public sealed class GameAudioPreviewCursorState
+    {
+        public GameAudioPreviewCursorState(
+            double musicalSeconds,
+            float musicalProgress,
+            int currentBar,
+            double beatInBar,
+            bool isInTail,
+            double tailSeconds)
+        {
+            MusicalSeconds = musicalSeconds;
+            MusicalProgress = musicalProgress;
+            CurrentBar = currentBar;
+            BeatInBar = beatInBar;
+            IsInTail = isInTail;
+            TailSeconds = tailSeconds;
+        }
+
+        public double MusicalSeconds { get; }
+
+        public float MusicalProgress { get; }
+
+        public int CurrentBar { get; }
+
+        public double BeatInBar { get; }
+
+        public bool IsInTail { get; }
+
+        public double TailSeconds { get; }
+    }
+}

--- a/Packages/com.example.gameaudiotool/Editor/Audio/GameAudioPreviewPlaybackService.cs
+++ b/Packages/com.example.gameaudiotool/Editor/Audio/GameAudioPreviewPlaybackService.cs
@@ -1,0 +1,305 @@
+using System;
+using GameAudioTool.Editor.Domain;
+using UnityEditor;
+using UnityEngine;
+
+namespace GameAudioTool.Editor.Audio
+{
+    public sealed class GameAudioPreviewPlaybackService : IDisposable
+    {
+        private readonly GameAudioProjectRenderer _renderer = new GameAudioProjectRenderer();
+
+        private GameAudioProject _boundProject;
+        private GameAudioRenderResult _renderResult;
+        private AudioClip _outputClip;
+        private AudioClip _loopClip;
+        private AudioClip _activeClip;
+        private bool _previewDirty = true;
+        private bool _isPlaying;
+        private bool _loopPlayback;
+        private double _playbackStartedAt;
+        private double _playbackSeconds;
+        private string _statusText = "Preview not rendered.";
+        private string _errorText = string.Empty;
+
+        public GameAudioPreviewState State => new GameAudioPreviewState(
+            _renderResult != null,
+            _isPlaying,
+            _loopPlayback,
+            _playbackSeconds,
+            _renderResult,
+            _statusText,
+            _errorText);
+
+        public void Dispose()
+        {
+            StopActiveClip();
+            DestroyPreviewClips();
+            _renderResult = null;
+        }
+
+        public void InvalidatePreview()
+        {
+            StopInternal(true, "Preview not rendered.");
+            _previewDirty = true;
+            _renderResult = null;
+            _errorText = string.Empty;
+            DestroyPreviewClips();
+        }
+
+        public GameAudioPreviewState Prepare(GameAudioProject project)
+        {
+            EnsurePreview(project);
+            return State;
+        }
+
+        public GameAudioPreviewState Play(GameAudioProject project, bool loopPlayback)
+        {
+            _loopPlayback = loopPlayback;
+            EnsurePreview(project);
+
+            if (_renderResult == null || _outputClip == null)
+            {
+                _statusText = "Preview render failed.";
+                return State;
+            }
+
+            AudioClip clipToPlay = _loopPlayback ? (_loopClip ?? _outputClip) : _outputClip;
+
+            try
+            {
+                StopActiveClip();
+                GameAudioEditorAudioUtility.PlayPreviewClip(clipToPlay, _loopPlayback);
+                _activeClip = clipToPlay;
+                _isPlaying = true;
+                _playbackStartedAt = EditorApplication.timeSinceStartup;
+                _playbackSeconds = 0.0d;
+                _errorText = string.Empty;
+                _statusText = _loopPlayback
+                    ? "Loop preview playing."
+                    : "Preview playing.";
+            }
+            catch (Exception exception)
+            {
+                StopInternal(true, "Preview start failed.");
+                _errorText = exception.Message;
+            }
+
+            return State;
+        }
+
+        public GameAudioPreviewState Stop()
+        {
+            if (_renderResult == null)
+            {
+                _statusText = "Preview not rendered.";
+                return State;
+            }
+
+            StopInternal(true, "Preview stopped.");
+            return State;
+        }
+
+        public GameAudioPreviewState Rewind()
+        {
+            if (_renderResult == null)
+            {
+                _statusText = "Preview not rendered.";
+                return State;
+            }
+
+            StopInternal(true, "Preview rewound.");
+            return State;
+        }
+
+        public GameAudioPreviewState SetLoopPlayback(bool loopPlayback)
+        {
+            bool loopChanged = _loopPlayback != loopPlayback;
+            _loopPlayback = loopPlayback;
+
+            if (_renderResult == null)
+            {
+                return State;
+            }
+
+            if (_isPlaying && loopChanged && _boundProject != null)
+            {
+                return Play(_boundProject, _loopPlayback);
+            }
+
+            _statusText = _loopPlayback
+                ? "Loop preview ready."
+                : "Preview ready.";
+            return State;
+        }
+
+        public bool Update()
+        {
+            if (!_isPlaying || _renderResult == null)
+            {
+                return false;
+            }
+
+            double elapsedSeconds = Math.Max(0.0d, EditorApplication.timeSinceStartup - _playbackStartedAt);
+            double previousSeconds = _playbackSeconds;
+
+            if (_loopPlayback)
+            {
+                double loopDurationSeconds = State.ProjectDurationSeconds;
+                if (loopDurationSeconds <= 0.0d)
+                {
+                    StopInternal(true, "Preview ready.");
+                    return true;
+                }
+
+                if (!GameAudioEditorAudioUtility.SupportsNativeLooping && elapsedSeconds >= loopDurationSeconds)
+                {
+                    double completedLoops = Math.Floor(elapsedSeconds / loopDurationSeconds);
+                    if (completedLoops >= 1.0d)
+                    {
+                        _playbackStartedAt += completedLoops * loopDurationSeconds;
+                        elapsedSeconds = Math.Max(0.0d, elapsedSeconds - (completedLoops * loopDurationSeconds));
+
+                        try
+                        {
+                            StopActiveClip();
+                            GameAudioEditorAudioUtility.PlayPreviewClip(_loopClip ?? _outputClip, false);
+                            _activeClip = _loopClip ?? _outputClip;
+                        }
+                        catch (Exception exception)
+                        {
+                            StopInternal(true, "Preview loop restart failed.");
+                            _errorText = exception.Message;
+                            return true;
+                        }
+                    }
+                }
+
+                _playbackSeconds = NormalizeLoopSeconds(elapsedSeconds, loopDurationSeconds);
+                return Math.Abs(previousSeconds - _playbackSeconds) > 0.0005d;
+            }
+
+            double outputDurationSeconds = State.OutputDurationSeconds;
+            _playbackSeconds = Math.Min(outputDurationSeconds, elapsedSeconds);
+            if (elapsedSeconds >= outputDurationSeconds)
+            {
+                StopActiveClip();
+                _isPlaying = false;
+                _statusText = "Preview complete.";
+                return true;
+            }
+
+            return Math.Abs(previousSeconds - _playbackSeconds) > 0.0005d;
+        }
+
+        private void EnsurePreview(GameAudioProject project)
+        {
+            if (project == null)
+            {
+                throw new ArgumentNullException(nameof(project));
+            }
+
+            _boundProject = project;
+
+            if (!_previewDirty && _renderResult != null && _outputClip != null)
+            {
+                if (!_isPlaying)
+                {
+                    _statusText = _loopPlayback ? "Loop preview ready." : "Preview ready.";
+                }
+
+                return;
+            }
+
+            StopActiveClip();
+            DestroyPreviewClips();
+
+            _renderResult = _renderer.Render(project);
+            _outputClip = CreateClip($"{project.Name}-preview", _renderResult.Samples, _renderResult.FrameCount, _renderResult.ChannelCount, _renderResult.SampleRate);
+
+            if (_renderResult.ProjectFrameCount < _renderResult.FrameCount)
+            {
+                int loopSampleCount = _renderResult.ProjectFrameCount * _renderResult.ChannelCount;
+                float[] loopSamples = new float[loopSampleCount];
+                Array.Copy(_renderResult.Samples, loopSamples, loopSampleCount);
+                _loopClip = CreateClip($"{project.Name}-loop", loopSamples, _renderResult.ProjectFrameCount, _renderResult.ChannelCount, _renderResult.SampleRate);
+            }
+            else
+            {
+                _loopClip = _outputClip;
+            }
+
+            _previewDirty = false;
+            _isPlaying = false;
+            _playbackSeconds = 0.0d;
+            _errorText = string.Empty;
+            _statusText = !GameAudioEditorAudioUtility.IsAvailable
+                ? "Preview ready. Unity editor playback API is unavailable."
+                : _renderResult.PeakAmplitude <= 0.0001f
+                    ? "Preview ready (silent buffer)."
+                    : "Preview ready.";
+        }
+
+        private static double NormalizeLoopSeconds(double elapsedSeconds, double loopDurationSeconds)
+        {
+            if (loopDurationSeconds <= 0.0d)
+            {
+                return 0.0d;
+            }
+
+            double normalized = elapsedSeconds % loopDurationSeconds;
+            return normalized < 0.0d
+                ? normalized + loopDurationSeconds
+                : normalized;
+        }
+
+        private static AudioClip CreateClip(string name, float[] samples, int frameCount, int channelCount, int sampleRate)
+        {
+            AudioClip clip = AudioClip.Create(name, frameCount, channelCount, sampleRate, false);
+            clip.hideFlags = HideFlags.HideAndDontSave;
+            clip.SetData(samples, 0);
+            return clip;
+        }
+
+        private void StopInternal(bool resetCursor, string statusText)
+        {
+            StopActiveClip();
+            _isPlaying = false;
+            if (resetCursor)
+            {
+                _playbackSeconds = 0.0d;
+            }
+
+            _statusText = statusText;
+        }
+
+        private void StopActiveClip()
+        {
+            if (_activeClip == null)
+            {
+                return;
+            }
+
+            GameAudioEditorAudioUtility.StopPreviewClip(_activeClip);
+            _activeClip = null;
+        }
+
+        private void DestroyPreviewClips()
+        {
+            AudioClip outputClip = _outputClip;
+            AudioClip loopClip = _loopClip;
+            _outputClip = null;
+            _loopClip = null;
+
+            if (outputClip != null)
+            {
+                UnityEngine.Object.DestroyImmediate(outputClip);
+            }
+
+            if (loopClip != null && loopClip != outputClip)
+            {
+                UnityEngine.Object.DestroyImmediate(loopClip);
+            }
+        }
+    }
+}

--- a/Packages/com.example.gameaudiotool/Editor/Audio/GameAudioPreviewState.cs
+++ b/Packages/com.example.gameaudiotool/Editor/Audio/GameAudioPreviewState.cs
@@ -1,0 +1,49 @@
+namespace GameAudioTool.Editor.Audio
+{
+    public sealed class GameAudioPreviewState
+    {
+        public GameAudioPreviewState(
+            bool isPreviewReady,
+            bool isPlaying,
+            bool loopPlayback,
+            double playbackSeconds,
+            GameAudioRenderResult renderResult,
+            string statusText,
+            string errorText)
+        {
+            IsPreviewReady = isPreviewReady;
+            IsPlaying = isPlaying;
+            LoopPlayback = loopPlayback;
+            PlaybackSeconds = playbackSeconds;
+            RenderResult = renderResult;
+            StatusText = statusText ?? string.Empty;
+            ErrorText = errorText ?? string.Empty;
+        }
+
+        public bool IsPreviewReady { get; }
+
+        public bool IsPlaying { get; }
+
+        public bool LoopPlayback { get; }
+
+        public double PlaybackSeconds { get; }
+
+        public GameAudioRenderResult RenderResult { get; }
+
+        public string StatusText { get; }
+
+        public string ErrorText { get; }
+
+        public int SampleRate => RenderResult?.SampleRate ?? 0;
+
+        public int ChannelCount => RenderResult?.ChannelCount ?? 0;
+
+        public float PeakAmplitude => RenderResult?.PeakAmplitude ?? 0.0f;
+
+        public double ProjectDurationSeconds => RenderResult == null || RenderResult.SampleRate <= 0
+            ? 0.0d
+            : RenderResult.ProjectFrameCount / (double)RenderResult.SampleRate;
+
+        public double OutputDurationSeconds => RenderResult?.DurationSeconds ?? 0.0d;
+    }
+}

--- a/Packages/com.example.gameaudiotool/Editor/Persistence/GameAudioCommonConfigSerializer.cs
+++ b/Packages/com.example.gameaudiotool/Editor/Persistence/GameAudioCommonConfigSerializer.cs
@@ -116,3 +116,4 @@ namespace GameAudioTool.Editor.Persistence
             };
         }
     }
+}

--- a/Packages/com.example.gameaudiotool/Editor/Persistence/GameAudioProjectConfigSerializer.cs
+++ b/Packages/com.example.gameaudiotool/Editor/Persistence/GameAudioProjectConfigSerializer.cs
@@ -108,3 +108,4 @@ namespace GameAudioTool.Editor.Persistence
             };
         }
     }
+}

--- a/Packages/com.example.gameaudiotool/Editor/Persistence/GameAudioProjectSchemaValidator.cs
+++ b/Packages/com.example.gameaudiotool/Editor/Persistence/GameAudioProjectSchemaValidator.cs
@@ -195,7 +195,7 @@ namespace GameAudioTool.Editor.Persistence
 
         public GameAudioJsonKind Kind { get; }
 
-        public IReadOnlyList<GameAudioJsonNode> Items => _items ?? (IReadOnlyList<GameAudioJsonNode>)Array.Empty<GameAudioJsonNode>();
+        public IReadOnlyList<GameAudioJsonNode> Items => _items ?? (IReadOnlyList<GameAudioJsonNode>)System.Array.Empty<GameAudioJsonNode>();
 
         public static GameAudioJsonNode Object(Dictionary<string, GameAudioJsonNode> properties)
         {

--- a/Packages/com.example.gameaudiotool/Editor/Windows/GameAudioToolWindow.cs
+++ b/Packages/com.example.gameaudiotool/Editor/Windows/GameAudioToolWindow.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using GameAudioTool.Editor.Application;
+using GameAudioTool.Editor.Audio;
 using GameAudioTool.Editor.Config;
 using GameAudioTool.Editor.Domain;
 using GameAudioTool.Editor.Persistence;
@@ -14,6 +15,7 @@ namespace GameAudioTool.Editor.Windows
     public sealed class GameAudioToolWindow : EditorWindow
     {
         private readonly GameAudioCommonConfigSerializer _commonConfigSerializer = new GameAudioCommonConfigSerializer();
+        private readonly GameAudioPreviewPlaybackService _previewPlaybackService = new GameAudioPreviewPlaybackService();
         private readonly GameAudioProjectSerializer _projectSerializer = new GameAudioProjectSerializer();
         private readonly GameAudioProjectConfigSerializer _projectConfigSerializer = new GameAudioProjectConfigSerializer();
 
@@ -21,6 +23,7 @@ namespace GameAudioTool.Editor.Windows
         private string _projectPath = string.Empty;
         private bool _isDirty;
         private List<string> _loadWarnings = new List<string>();
+        private IVisualElementScheduledItem _previewTicker;
 
         private Label _nameValue;
         private Label _bpmValue;
@@ -29,13 +32,19 @@ namespace GameAudioTool.Editor.Windows
         private Label _pathValue;
         private Label _statusValue;
         private HelpBox _warningBox;
+        private Label _previewStateValue;
+        private Label _previewBufferValue;
+        private Label _previewCursorValue;
+        private ProgressBar _previewProgressBar;
+        private Toggle _loopToggle;
+        private HelpBox _previewHelpBox;
 
         [MenuItem("Tools/Torus Edison/Open Editor")]
         public static void OpenWindow()
         {
             var window = GetWindow<GameAudioToolWindow>();
             window.titleContent = new GUIContent(GameAudioToolInfo.DisplayName);
-            window.minSize = new Vector2(560.0f, 340.0f);
+            window.minSize = new Vector2(640.0f, 420.0f);
             window.Show();
         }
 
@@ -45,6 +54,7 @@ namespace GameAudioTool.Editor.Windows
             {
                 _project = CreateConfiguredProject();
                 _isDirty = true;
+                ResetPreviewState();
             }
 
             rootVisualElement.Clear();
@@ -56,7 +66,11 @@ namespace GameAudioTool.Editor.Windows
 
             rootVisualElement.Add(BuildToolbar());
             rootVisualElement.Add(BuildSummaryPanel());
+            rootVisualElement.Add(BuildPreviewPanel());
             rootVisualElement.Add(BuildInfoPanel());
+
+            _previewTicker?.Pause();
+            _previewTicker = rootVisualElement.schedule.Execute(HandlePreviewTick).Every(50);
 
             RefreshView();
         }
@@ -65,7 +79,6 @@ namespace GameAudioTool.Editor.Windows
         {
             var container = new VisualElement();
             container.style.flexDirection = FlexDirection.Row;
-            container.style.gap = 8;
             container.style.marginBottom = 12;
 
             container.Add(CreateToolbarButton("New", CreateNewProject));
@@ -78,22 +91,7 @@ namespace GameAudioTool.Editor.Windows
 
         private VisualElement BuildSummaryPanel()
         {
-            var panel = new VisualElement();
-            panel.style.flexDirection = FlexDirection.Column;
-            panel.style.marginBottom = 12;
-            panel.style.paddingTop = 12;
-            panel.style.paddingBottom = 12;
-            panel.style.paddingLeft = 12;
-            panel.style.paddingRight = 12;
-            panel.style.borderTopWidth = 1;
-            panel.style.borderRightWidth = 1;
-            panel.style.borderBottomWidth = 1;
-            panel.style.borderLeftWidth = 1;
-            panel.style.borderTopColor = new Color(0.23f, 0.23f, 0.23f);
-            panel.style.borderRightColor = new Color(0.23f, 0.23f, 0.23f);
-            panel.style.borderBottomColor = new Color(0.23f, 0.23f, 0.23f);
-            panel.style.borderLeftColor = new Color(0.23f, 0.23f, 0.23f);
-            panel.style.backgroundColor = new Color(0.16f, 0.16f, 0.16f);
+            var panel = CreateSectionPanel(new Color(0.16f, 0.16f, 0.16f));
 
             panel.Add(CreateSectionTitle("Current Project"));
             _nameValue = AddKeyValue(panel, "Name");
@@ -106,15 +104,67 @@ namespace GameAudioTool.Editor.Windows
             return panel;
         }
 
+        private VisualElement BuildPreviewPanel()
+        {
+            var panel = CreateSectionPanel(new Color(0.13f, 0.13f, 0.13f));
+
+            panel.Add(CreateSectionTitle("Preview Playback"));
+
+            var transportRow = new VisualElement();
+            transportRow.style.flexDirection = FlexDirection.Row;
+            transportRow.style.alignItems = Align.Center;
+            transportRow.style.marginBottom = 8;
+
+            transportRow.Add(CreateToolbarButton("Render Preview", RenderPreview));
+            transportRow.Add(CreateToolbarButton("Play", PlayPreview));
+            transportRow.Add(CreateToolbarButton("Stop", StopPreview));
+            transportRow.Add(CreateToolbarButton("Rewind", RewindPreview));
+
+            _loopToggle = new Toggle("Loop");
+            _loopToggle.style.marginLeft = 4;
+            _loopToggle.RegisterValueChangedCallback(OnLoopPlaybackChanged);
+            transportRow.Add(_loopToggle);
+
+            panel.Add(transportRow);
+
+            _previewStateValue = AddKeyValue(panel, "Preview");
+            _previewBufferValue = AddKeyValue(panel, "Buffer");
+            _previewCursorValue = AddKeyValue(panel, "Cursor");
+
+            _previewProgressBar = new ProgressBar
+            {
+                title = "Cursor not started"
+            };
+            _previewProgressBar.lowValue = 0.0f;
+            _previewProgressBar.highValue = 100.0f;
+            _previewProgressBar.style.marginTop = 4;
+            panel.Add(_previewProgressBar);
+
+            _previewHelpBox = new HelpBox(string.Empty, HelpBoxMessageType.Warning)
+            {
+                style =
+                {
+                    display = DisplayStyle.None
+                }
+            };
+            panel.Add(_previewHelpBox);
+
+            return panel;
+        }
+
         private VisualElement BuildInfoPanel()
         {
             var panel = new VisualElement();
             panel.style.flexDirection = FlexDirection.Column;
-            panel.style.gap = 8;
 
             panel.Add(CreateSectionTitle("Foundation Status"));
-            panel.Add(new Label("This initial window wires up project creation, JSON save/load, and package scaffolding."));
-            panel.Add(new Label("Timeline editing, playback, WAV export, and Undo/Redo are the next layers to connect."));
+            var currentScopeLabel = new Label("This window now wires up project creation, JSON save/load, offline preview rendering, and editor playback.");
+            currentScopeLabel.style.marginBottom = 4;
+            panel.Add(currentScopeLabel);
+
+            var nextScopeLabel = new Label("Timeline editing, WAV export, and Undo/Redo are the next layers to connect.");
+            nextScopeLabel.style.marginBottom = 8;
+            panel.Add(nextScopeLabel);
 
             _warningBox = new HelpBox(string.Empty, HelpBoxMessageType.Warning)
             {
@@ -136,10 +186,32 @@ namespace GameAudioTool.Editor.Windows
             };
 
             button.style.minWidth = 84;
+            button.style.marginRight = 8;
             return button;
         }
 
-        private Label AddKeyValue(VisualElement parent, string key)
+        private static VisualElement CreateSectionPanel(Color backgroundColor)
+        {
+            var panel = new VisualElement();
+            panel.style.flexDirection = FlexDirection.Column;
+            panel.style.marginBottom = 12;
+            panel.style.paddingTop = 12;
+            panel.style.paddingBottom = 12;
+            panel.style.paddingLeft = 12;
+            panel.style.paddingRight = 12;
+            panel.style.borderTopWidth = 1;
+            panel.style.borderRightWidth = 1;
+            panel.style.borderBottomWidth = 1;
+            panel.style.borderLeftWidth = 1;
+            panel.style.borderTopColor = new Color(0.23f, 0.23f, 0.23f);
+            panel.style.borderRightColor = new Color(0.23f, 0.23f, 0.23f);
+            panel.style.borderBottomColor = new Color(0.23f, 0.23f, 0.23f);
+            panel.style.borderLeftColor = new Color(0.23f, 0.23f, 0.23f);
+            panel.style.backgroundColor = backgroundColor;
+            return panel;
+        }
+
+        private static Label AddKeyValue(VisualElement parent, string key)
         {
             var row = new VisualElement();
             row.style.flexDirection = FlexDirection.Row;
@@ -159,7 +231,7 @@ namespace GameAudioTool.Editor.Windows
             return valueLabel;
         }
 
-        private Label CreateSectionTitle(string text)
+        private static Label CreateSectionTitle(string text)
         {
             var label = new Label(text);
             label.style.unityFontStyleAndWeight = FontStyle.Bold;
@@ -178,6 +250,7 @@ namespace GameAudioTool.Editor.Windows
             _projectPath = string.Empty;
             _isDirty = true;
             _loadWarnings.Clear();
+            ResetPreviewState();
             RefreshView();
         }
 
@@ -188,7 +261,7 @@ namespace GameAudioTool.Editor.Windows
                 return;
             }
 
-            string selectedPath = EditorUtility.OpenFilePanel("Open Game Audio Project", string.IsNullOrWhiteSpace(_projectPath) ? Application.dataPath : _projectPath, "json");
+            string selectedPath = EditorUtility.OpenFilePanel("Open Game Audio Project", string.IsNullOrWhiteSpace(_projectPath) ? UnityEngine.Application.dataPath : _projectPath, "json");
             if (string.IsNullOrWhiteSpace(selectedPath))
             {
                 return;
@@ -201,6 +274,7 @@ namespace GameAudioTool.Editor.Windows
                 _projectPath = selectedPath;
                 _isDirty = false;
                 _loadWarnings = new List<string>(loadResult.Warnings);
+                ResetPreviewState();
                 ShowNotification(new GUIContent("Project loaded."));
                 RefreshView();
             }
@@ -227,7 +301,7 @@ namespace GameAudioTool.Editor.Windows
             string defaultFileName = $"{GameAudioValidationUtility.SanitizeExportFileName(projectName)}{GameAudioToolInfo.SessionFileExtension}";
             string selectedPath = EditorUtility.SaveFilePanel(
                 "Save Game Audio Project",
-                string.IsNullOrWhiteSpace(_projectPath) ? Application.dataPath : System.IO.Path.GetDirectoryName(_projectPath),
+                string.IsNullOrWhiteSpace(_projectPath) ? UnityEngine.Application.dataPath : System.IO.Path.GetDirectoryName(_projectPath),
                 defaultFileName,
                 "json");
 
@@ -293,6 +367,75 @@ namespace GameAudioTool.Editor.Windows
             return GameAudioProjectFactory.CreateDefaultProject(sampleRate, channelMode);
         }
 
+        private void RenderPreview()
+        {
+            try
+            {
+                _previewPlaybackService.Prepare(_project);
+                RefreshView();
+                ShowNotification(new GUIContent("Preview rendered."));
+            }
+            catch (Exception exception)
+            {
+                EditorUtility.DisplayDialog(GameAudioToolInfo.DisplayName, exception.Message, "OK");
+            }
+        }
+
+        private void PlayPreview()
+        {
+            try
+            {
+                _previewPlaybackService.Play(_project, _project != null && _project.LoopPlayback);
+                RefreshView();
+            }
+            catch (Exception exception)
+            {
+                EditorUtility.DisplayDialog(GameAudioToolInfo.DisplayName, exception.Message, "OK");
+            }
+        }
+
+        private void StopPreview()
+        {
+            _previewPlaybackService.Stop();
+            RefreshView();
+        }
+
+        private void RewindPreview()
+        {
+            _previewPlaybackService.Rewind();
+            RefreshView();
+        }
+
+        private void OnLoopPlaybackChanged(ChangeEvent<bool> evt)
+        {
+            if (_project == null || _project.LoopPlayback == evt.newValue)
+            {
+                return;
+            }
+
+            _project.LoopPlayback = evt.newValue;
+            _isDirty = true;
+            _previewPlaybackService.SetLoopPlayback(evt.newValue);
+            RefreshView();
+        }
+
+        private void HandlePreviewTick()
+        {
+            if (_previewPlaybackService.Update())
+            {
+                RefreshView();
+            }
+        }
+
+        private void ResetPreviewState()
+        {
+            _previewPlaybackService.InvalidatePreview();
+            if (_project != null)
+            {
+                _previewPlaybackService.SetLoopPlayback(_project.LoopPlayback);
+            }
+        }
+
         private void RefreshView()
         {
             titleContent = new GUIContent(_isDirty ? $"{GameAudioToolInfo.DisplayName}*" : GameAudioToolInfo.DisplayName);
@@ -308,6 +451,39 @@ namespace GameAudioTool.Editor.Windows
             _tracksValue.text = _project.Tracks.Count.ToString();
             _pathValue.text = string.IsNullOrWhiteSpace(_projectPath) ? "(unsaved)" : _projectPath;
             _statusValue.text = _isDirty ? "Unsaved changes" : "Saved";
+            _loopToggle.SetValueWithoutNotify(_project.LoopPlayback);
+
+            GameAudioPreviewState previewState = _previewPlaybackService.State;
+            GameAudioPreviewCursorState cursorState = GameAudioPreviewCursorCalculator.Calculate(_project, previewState);
+            _previewStateValue.text = previewState.StatusText;
+            _previewBufferValue.text = BuildPreviewBufferText(previewState);
+            _previewCursorValue.text = previewState.IsPreviewReady
+                ? BuildPreviewCursorText(cursorState)
+                : "(not rendered)";
+            _previewProgressBar.value = previewState.IsPreviewReady
+                ? cursorState.MusicalProgress * 100.0f
+                : 0.0f;
+            _previewProgressBar.title = previewState.IsPreviewReady
+                ? cursorState.IsInTail
+                    ? $"Playback tail +{cursorState.TailSeconds:0.00}s"
+                    : $"Bar {cursorState.CurrentBar:00} / Beat {cursorState.BeatInBar:0.00}"
+                : "Cursor not started";
+
+            if (!string.IsNullOrWhiteSpace(previewState.ErrorText))
+            {
+                _previewHelpBox.text = previewState.ErrorText;
+                _previewHelpBox.style.display = DisplayStyle.Flex;
+            }
+            else if (previewState.IsPreviewReady && !GameAudioEditorAudioUtility.IsAvailable)
+            {
+                _previewHelpBox.text = "Render is available, but UnityEditor preview playback API was not found in this editor build.";
+                _previewHelpBox.style.display = DisplayStyle.Flex;
+            }
+            else
+            {
+                _previewHelpBox.text = string.Empty;
+                _previewHelpBox.style.display = DisplayStyle.None;
+            }
 
             if (_loadWarnings.Count > 0)
             {
@@ -319,6 +495,35 @@ namespace GameAudioTool.Editor.Windows
                 _warningBox.text = string.Empty;
                 _warningBox.style.display = DisplayStyle.None;
             }
+        }
+
+        private static string BuildPreviewBufferText(GameAudioPreviewState previewState)
+        {
+            if (!previewState.IsPreviewReady || previewState.RenderResult == null)
+            {
+                return "(not rendered)";
+            }
+
+            string channelLabel = previewState.ChannelCount == 1 ? "Mono" : "Stereo";
+            return $"{previewState.SampleRate} Hz / {channelLabel} / project {previewState.ProjectDurationSeconds:0.00}s / output {previewState.OutputDurationSeconds:0.00}s / peak {previewState.PeakAmplitude:0.000}";
+        }
+
+        private static string BuildPreviewCursorText(GameAudioPreviewCursorState cursorState)
+        {
+            string cursorText = $"Bar {cursorState.CurrentBar:00} / Beat {cursorState.BeatInBar:0.00} ({cursorState.MusicalSeconds:0.00}s)";
+            if (!cursorState.IsInTail)
+            {
+                return cursorText;
+            }
+
+            return $"{cursorText} / tail +{cursorState.TailSeconds:0.00}s";
+        }
+
+        private void OnDisable()
+        {
+            _previewTicker?.Pause();
+            _previewTicker = null;
+            _previewPlaybackService.Dispose();
         }
     }
 }

--- a/Packages/com.example.gameaudiotool/Tests/Editor/GameAudioPreviewCursorCalculatorTests.cs
+++ b/Packages/com.example.gameaudiotool/Tests/Editor/GameAudioPreviewCursorCalculatorTests.cs
@@ -1,0 +1,81 @@
+using NUnit.Framework;
+using GameAudioTool.Editor.Application;
+using GameAudioTool.Editor.Audio;
+
+namespace GameAudioTool.Editor.Tests
+{
+    public sealed class GameAudioPreviewCursorCalculatorTests
+    {
+        [Test]
+        public void Calculate_StartsAtBarOneBeatOne()
+        {
+            var project = GameAudioProjectFactory.CreateDefaultProject();
+            project.TotalBars = 4;
+            project.Bpm = 120;
+
+            var previewState = new GameAudioPreviewState(
+                true,
+                false,
+                false,
+                0.0d,
+                new GameAudioRenderResult(new float[0], 48000, 2, 48000 * 9, 48000 * 8, 0.0f),
+                "Preview ready.",
+                string.Empty);
+
+            GameAudioPreviewCursorState cursor = GameAudioPreviewCursorCalculator.Calculate(project, previewState);
+
+            Assert.That(cursor.CurrentBar, Is.EqualTo(1));
+            Assert.That(cursor.BeatInBar, Is.EqualTo(1.0d));
+            Assert.That(cursor.MusicalProgress, Is.EqualTo(0.0f));
+            Assert.That(cursor.IsInTail, Is.False);
+        }
+
+        [Test]
+        public void Calculate_ClampsTailToProjectEnd()
+        {
+            var project = GameAudioProjectFactory.CreateDefaultProject();
+            project.TotalBars = 4;
+            project.Bpm = 120;
+
+            var previewState = new GameAudioPreviewState(
+                true,
+                false,
+                false,
+                8.5d,
+                new GameAudioRenderResult(new float[0], 48000, 2, 48000 * 9, 48000 * 8, 0.0f),
+                "Preview complete.",
+                string.Empty);
+
+            GameAudioPreviewCursorState cursor = GameAudioPreviewCursorCalculator.Calculate(project, previewState);
+
+            Assert.That(cursor.CurrentBar, Is.EqualTo(4));
+            Assert.That(cursor.BeatInBar, Is.EqualTo(4.0d));
+            Assert.That(cursor.MusicalProgress, Is.EqualTo(1.0f));
+            Assert.That(cursor.IsInTail, Is.True);
+            Assert.That(cursor.TailSeconds, Is.EqualTo(0.5d).Within(0.0001d));
+        }
+
+        [Test]
+        public void Calculate_MapsTimeIntoBarAndBeat()
+        {
+            var project = GameAudioProjectFactory.CreateDefaultProject();
+            project.TotalBars = 4;
+            project.Bpm = 120;
+
+            var previewState = new GameAudioPreviewState(
+                true,
+                true,
+                false,
+                2.25d,
+                new GameAudioRenderResult(new float[0], 48000, 2, 48000 * 9, 48000 * 8, 0.0f),
+                "Preview playing.",
+                string.Empty);
+
+            GameAudioPreviewCursorState cursor = GameAudioPreviewCursorCalculator.Calculate(project, previewState);
+
+            Assert.That(cursor.CurrentBar, Is.EqualTo(2));
+            Assert.That(cursor.BeatInBar, Is.EqualTo(1.5d).Within(0.0001d));
+            Assert.That(cursor.MusicalSeconds, Is.EqualTo(2.25d).Within(0.0001d));
+        }
+    }
+}

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -45,5 +45,8 @@
     "com.unity.modules.vr": "1.0.0",
     "com.unity.modules.wind": "1.0.0",
     "com.unity.modules.xr": "1.0.0"
-  }
+  },
+  "testables": [
+    "com.example.gameaudiotool"
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -24,13 +24,12 @@ Current foundation in this repository:
 - `.gats.json` save/load foundation with validation
 - common/project config serializers
 - deterministic offline audio rendering core for waveform, noise, ADSR, delay, and mixdown
-- minimal Editor window entry point
+- editor preview playback with Play / Stop / Rewind / Loop transport controls
 - sample session files and starter release documentation
 
 Not implemented yet:
 
 - timeline editing UI
-- audio preview playback
 - WAV export
 - Undo / Redo command history
 


### PR DESCRIPTION
## What changed
- added an editor-side preview playback service that renders the current project into preview `AudioClip` buffers
- added Play, Stop, Rewind, Loop, and cursor/progress reporting to the Torus Edison editor window
- separated preview cursor math and added editor tests for cursor and tail reporting
- enabled host-project package tests via `Packages/manifest.json` `testables`
- fixed compile blockers discovered during Unity validation in the config serializers and JSON schema helper

## Why
- issue #4 requires editor preview playback, loop handling based on `Total Bars`, and a visible playback cursor before timeline editing work can continue safely

## Validation
- `git diff --check`
- Unity 6000.4.0f1 batch compile on a temp project copy under `D:\Claude\UnityEditor-Dev\.tmp\SoundCreater-issue4-validation`
- Unity batch import/compile exits successfully after the preview changes and related compile-blocker fixes

## Remaining manual check
- open the editor window in the normal Unity UI once and verify audible Play / Stop / Loop behavior and visible cursor movement in-editor
- Unity batch `-runTests` currently exits successfully but did not emit `TestResults.xml`, so Test Runner artifact verification is still unresolved
