### PR TITLE
Fix preview playback and add pause support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,10 @@ Desktop.ini
 # Generated release artifacts
 *.unitypackage
 *.zip
+
+# Editor preview cache
+Assets/__TorusEdisonPreviewCache__/
+Assets/__TorusEdisonPreviewCache__.meta
+
+# Local user projects
+myAudioProjects/

--- a/Packages/com.example.gameaudiotool/Editor/Audio/GameAudioEditorAudioUtility.cs
+++ b/Packages/com.example.gameaudiotool/Editor/Audio/GameAudioEditorAudioUtility.cs
@@ -26,7 +26,7 @@ namespace GameAudioTool.Editor.Audio
         public static bool SupportsNativeLooping => PlayPreviewClipMethod != null
             && PlayPreviewClipMethod.GetParameters().Any(parameter => parameter.ParameterType == typeof(bool));
 
-        public static void PlayPreviewClip(AudioClip clip, bool loopPlayback)
+        public static void PlayPreviewClip(AudioClip clip, bool loopPlayback, int startSample = 0)
         {
             if (clip == null)
             {
@@ -38,7 +38,7 @@ namespace GameAudioTool.Editor.Audio
                 throw new InvalidOperationException("UnityEditor preview audio API is unavailable in this editor build.");
             }
 
-            object[] arguments = BuildPlayArguments(PlayPreviewClipMethod, clip, loopPlayback);
+            object[] arguments = BuildPlayArguments(PlayPreviewClipMethod, clip, loopPlayback, Math.Max(0, startSample));
             PlayPreviewClipMethod.Invoke(null, arguments);
         }
 
@@ -160,11 +160,12 @@ namespace GameAudioTool.Editor.Audio
             return true;
         }
 
-        private static object[] BuildPlayArguments(MethodInfo method, AudioClip clip, bool loopPlayback)
+        private static object[] BuildPlayArguments(MethodInfo method, AudioClip clip, bool loopPlayback, int startSample)
         {
             ParameterInfo[] parameters = method.GetParameters();
             object[] arguments = new object[parameters.Length];
             arguments[0] = clip;
+            bool wroteStartSample = false;
 
             for (int index = 1; index < parameters.Length; index++)
             {
@@ -175,7 +176,8 @@ namespace GameAudioTool.Editor.Audio
                 }
                 else if (parameterType == typeof(int))
                 {
-                    arguments[index] = 0;
+                    arguments[index] = wroteStartSample ? 0 : startSample;
+                    wroteStartSample = true;
                 }
                 else
                 {

--- a/Packages/com.example.gameaudiotool/Editor/Audio/GameAudioPreviewClipAssetCache.cs
+++ b/Packages/com.example.gameaudiotool/Editor/Audio/GameAudioPreviewClipAssetCache.cs
@@ -1,0 +1,140 @@
+using System;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+namespace GameAudioTool.Editor.Audio
+{
+    internal sealed class GameAudioPreviewClipAssetCache
+    {
+        private const string CacheFolderName = "__TorusEdisonPreviewCache__";
+        private readonly string _sessionToken = Guid.NewGuid().ToString("N");
+
+        private string _outputAssetPath;
+        private string _loopAssetPath;
+
+        public AudioClip CreateOutputClip(string projectName, GameAudioRenderResult renderResult)
+        {
+            if (renderResult == null)
+            {
+                throw new ArgumentNullException(nameof(renderResult));
+            }
+
+            _outputAssetPath = WriteClipAsset(projectName, "output", renderResult.Samples, renderResult.FrameCount, renderResult.ChannelCount, renderResult.SampleRate);
+            return LoadClip(_outputAssetPath);
+        }
+
+        public AudioClip CreateLoopClip(string projectName, float[] samples, int frameCount, int channelCount, int sampleRate)
+        {
+            if (samples == null)
+            {
+                throw new ArgumentNullException(nameof(samples));
+            }
+
+            _loopAssetPath = WriteClipAsset(projectName, "loop", samples, frameCount, channelCount, sampleRate);
+            return LoadClip(_loopAssetPath);
+        }
+
+        public void Clear()
+        {
+            DeleteAsset(ref _outputAssetPath);
+            DeleteAsset(ref _loopAssetPath);
+        }
+
+        private static AudioClip LoadClip(string assetPath)
+        {
+            if (string.IsNullOrWhiteSpace(assetPath))
+            {
+                return null;
+            }
+
+            AssetDatabase.ImportAsset(assetPath, ImportAssetOptions.ForceUpdate | ImportAssetOptions.ForceSynchronousImport);
+            return AssetDatabase.LoadAssetAtPath<AudioClip>(assetPath);
+        }
+
+        private static void DeleteAsset(ref string assetPath)
+        {
+            if (string.IsNullOrWhiteSpace(assetPath))
+            {
+                return;
+            }
+
+            if (AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(assetPath) != null)
+            {
+                AssetDatabase.DeleteAsset(assetPath);
+            }
+
+            assetPath = null;
+        }
+
+        private string WriteClipAsset(string projectName, string role, float[] samples, int frameCount, int channelCount, int sampleRate)
+        {
+            if (frameCount <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(frameCount));
+            }
+
+            if (channelCount <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(channelCount));
+            }
+
+            EnsureCacheFolder();
+
+            string safeProjectName = SanitizeFileName(projectName);
+            string fileName = $"{safeProjectName}-{role}-{_sessionToken}.wav";
+            string absolutePath = Path.Combine(UnityEngine.Application.dataPath, CacheFolderName, fileName);
+            string assetPath = $"Assets/{CacheFolderName}/{fileName}";
+            byte[] wavBytes = GameAudioWavEncoder.EncodePcm16(samples, sampleRate, channelCount);
+
+            File.WriteAllBytes(absolutePath, wavBytes);
+            AssetDatabase.ImportAsset(assetPath, ImportAssetOptions.ForceUpdate | ImportAssetOptions.ForceSynchronousImport);
+
+            if (AssetImporter.GetAtPath(assetPath) is AudioImporter importer)
+            {
+                AudioImporterSampleSettings settings = importer.defaultSampleSettings;
+                settings.loadType = AudioClipLoadType.DecompressOnLoad;
+                settings.preloadAudioData = true;
+                settings.quality = 1.0f;
+                importer.defaultSampleSettings = settings;
+                importer.loadInBackground = false;
+                importer.forceToMono = channelCount == 1;
+                importer.SaveAndReimport();
+            }
+
+            return assetPath;
+        }
+
+        private static void EnsureCacheFolder()
+        {
+            string folderAssetPath = $"Assets/{CacheFolderName}";
+            if (!AssetDatabase.IsValidFolder(folderAssetPath))
+            {
+                AssetDatabase.CreateFolder("Assets", CacheFolderName);
+            }
+        }
+
+        private static string SanitizeFileName(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return "preview";
+            }
+
+            char[] invalidCharacters = Path.GetInvalidFileNameChars();
+            char[] buffer = value.ToCharArray();
+            for (int index = 0; index < buffer.Length; index++)
+            {
+                if (Array.IndexOf(invalidCharacters, buffer[index]) >= 0)
+                {
+                    buffer[index] = '_';
+                }
+            }
+
+            string sanitized = new string(buffer).Trim();
+            return string.IsNullOrWhiteSpace(sanitized)
+                ? "preview"
+                : sanitized.Replace(' ', '_');
+        }
+    }
+}

--- a/Packages/com.example.gameaudiotool/Editor/Audio/GameAudioPreviewClipAssetCache.cs.meta
+++ b/Packages/com.example.gameaudiotool/Editor/Audio/GameAudioPreviewClipAssetCache.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a416d72e1da01c4429b79cce3b0fe696

--- a/Packages/com.example.gameaudiotool/Editor/Audio/GameAudioPreviewPlaybackService.cs
+++ b/Packages/com.example.gameaudiotool/Editor/Audio/GameAudioPreviewPlaybackService.cs
@@ -7,6 +7,7 @@ namespace GameAudioTool.Editor.Audio
 {
     public sealed class GameAudioPreviewPlaybackService : IDisposable
     {
+        private readonly GameAudioPreviewClipAssetCache _clipAssetCache = new GameAudioPreviewClipAssetCache();
         private readonly GameAudioProjectRenderer _renderer = new GameAudioProjectRenderer();
 
         private GameAudioProject _boundProject;
@@ -16,6 +17,7 @@ namespace GameAudioTool.Editor.Audio
         private AudioClip _activeClip;
         private bool _previewDirty = true;
         private bool _isPlaying;
+        private bool _isPaused;
         private bool _loopPlayback;
         private double _playbackStartedAt;
         private double _playbackSeconds;
@@ -25,6 +27,7 @@ namespace GameAudioTool.Editor.Audio
         public GameAudioPreviewState State => new GameAudioPreviewState(
             _renderResult != null,
             _isPlaying,
+            _isPaused,
             _loopPlayback,
             _playbackSeconds,
             _renderResult,
@@ -65,15 +68,18 @@ namespace GameAudioTool.Editor.Audio
             }
 
             AudioClip clipToPlay = _loopPlayback ? (_loopClip ?? _outputClip) : _outputClip;
+            double resumeSeconds = _isPaused ? _playbackSeconds : 0.0d;
+            int startSample = _isPaused ? GetResumeStartSample(clipToPlay, resumeSeconds) : 0;
 
             try
             {
                 StopActiveClip();
-                GameAudioEditorAudioUtility.PlayPreviewClip(clipToPlay, _loopPlayback);
+                GameAudioEditorAudioUtility.PlayPreviewClip(clipToPlay, _loopPlayback, startSample);
                 _activeClip = clipToPlay;
                 _isPlaying = true;
-                _playbackStartedAt = EditorApplication.timeSinceStartup;
-                _playbackSeconds = 0.0d;
+                _isPaused = false;
+                _playbackStartedAt = EditorApplication.timeSinceStartup - resumeSeconds;
+                _playbackSeconds = resumeSeconds;
                 _errorText = string.Empty;
                 _statusText = _loopPlayback
                     ? "Loop preview playing."
@@ -85,6 +91,27 @@ namespace GameAudioTool.Editor.Audio
                 _errorText = exception.Message;
             }
 
+            return State;
+        }
+
+        public GameAudioPreviewState Pause()
+        {
+            if (_renderResult == null)
+            {
+                _statusText = "Preview not rendered.";
+                return State;
+            }
+
+            if (!_isPlaying)
+            {
+                _statusText = _isPaused
+                    ? (_loopPlayback ? "Loop preview paused." : "Preview paused.")
+                    : (_loopPlayback ? "Loop preview ready." : "Preview ready.");
+                return State;
+            }
+
+            _playbackSeconds = CalculatePlaybackSeconds(Math.Max(0.0d, EditorApplication.timeSinceStartup - _playbackStartedAt));
+            StopInternal(false, _loopPlayback ? "Loop preview paused." : "Preview paused.", true);
             return State;
         }
 
@@ -127,9 +154,18 @@ namespace GameAudioTool.Editor.Audio
                 return Play(_boundProject, _loopPlayback);
             }
 
-            _statusText = _loopPlayback
-                ? "Loop preview ready."
-                : "Preview ready.";
+            if (_isPaused)
+            {
+                _statusText = _loopPlayback
+                    ? "Loop preview paused."
+                    : "Preview paused.";
+            }
+            else
+            {
+                _statusText = _loopPlayback
+                    ? "Loop preview ready."
+                    : "Preview ready.";
+            }
             return State;
         }
 
@@ -175,16 +211,17 @@ namespace GameAudioTool.Editor.Audio
                     }
                 }
 
-                _playbackSeconds = NormalizeLoopSeconds(elapsedSeconds, loopDurationSeconds);
+                _playbackSeconds = CalculatePlaybackSeconds(elapsedSeconds);
                 return Math.Abs(previousSeconds - _playbackSeconds) > 0.0005d;
             }
 
             double outputDurationSeconds = State.OutputDurationSeconds;
-            _playbackSeconds = Math.Min(outputDurationSeconds, elapsedSeconds);
+            _playbackSeconds = CalculatePlaybackSeconds(elapsedSeconds);
             if (elapsedSeconds >= outputDurationSeconds)
             {
                 StopActiveClip();
                 _isPlaying = false;
+                _isPaused = false;
                 _statusText = "Preview complete.";
                 return true;
             }
@@ -205,7 +242,9 @@ namespace GameAudioTool.Editor.Audio
             {
                 if (!_isPlaying)
                 {
-                    _statusText = _loopPlayback ? "Loop preview ready." : "Preview ready.";
+                    _statusText = _isPaused
+                        ? (_loopPlayback ? "Loop preview paused." : "Preview paused.")
+                        : (_loopPlayback ? "Loop preview ready." : "Preview ready.");
                 }
 
                 return;
@@ -215,22 +254,28 @@ namespace GameAudioTool.Editor.Audio
             DestroyPreviewClips();
 
             _renderResult = _renderer.Render(project);
-            _outputClip = CreateClip($"{project.Name}-preview", _renderResult.Samples, _renderResult.FrameCount, _renderResult.ChannelCount, _renderResult.SampleRate);
+            _outputClip = _clipAssetCache.CreateOutputClip(project.Name, _renderResult);
 
             if (_renderResult.ProjectFrameCount < _renderResult.FrameCount)
             {
                 int loopSampleCount = _renderResult.ProjectFrameCount * _renderResult.ChannelCount;
                 float[] loopSamples = new float[loopSampleCount];
                 Array.Copy(_renderResult.Samples, loopSamples, loopSampleCount);
-                _loopClip = CreateClip($"{project.Name}-loop", loopSamples, _renderResult.ProjectFrameCount, _renderResult.ChannelCount, _renderResult.SampleRate);
+                _loopClip = _clipAssetCache.CreateLoopClip(project.Name, loopSamples, _renderResult.ProjectFrameCount, _renderResult.ChannelCount, _renderResult.SampleRate);
             }
             else
             {
                 _loopClip = _outputClip;
             }
 
+            if (_outputClip == null)
+            {
+                throw new InvalidOperationException("Preview clip asset could not be created.");
+            }
+
             _previewDirty = false;
             _isPlaying = false;
+            _isPaused = false;
             _playbackSeconds = 0.0d;
             _errorText = string.Empty;
             _statusText = !GameAudioEditorAudioUtility.IsAvailable
@@ -253,18 +298,37 @@ namespace GameAudioTool.Editor.Audio
                 : normalized;
         }
 
-        private static AudioClip CreateClip(string name, float[] samples, int frameCount, int channelCount, int sampleRate)
+        private double CalculatePlaybackSeconds(double elapsedSeconds)
         {
-            AudioClip clip = AudioClip.Create(name, frameCount, channelCount, sampleRate, false);
-            clip.hideFlags = HideFlags.HideAndDontSave;
-            clip.SetData(samples, 0);
-            return clip;
+            if (_renderResult == null)
+            {
+                return 0.0d;
+            }
+
+            if (_loopPlayback)
+            {
+                return NormalizeLoopSeconds(elapsedSeconds, State.ProjectDurationSeconds);
+            }
+
+            return Math.Min(State.OutputDurationSeconds, elapsedSeconds);
         }
 
-        private void StopInternal(bool resetCursor, string statusText)
+        private static int GetResumeStartSample(AudioClip clip, double resumeSeconds)
+        {
+            if (clip == null || clip.frequency <= 0 || clip.samples <= 0)
+            {
+                return 0;
+            }
+
+            int startSample = (int)Math.Round(Math.Max(0.0d, resumeSeconds) * clip.frequency);
+            return Math.Clamp(startSample, 0, Math.Max(0, clip.samples - 1));
+        }
+
+        private void StopInternal(bool resetCursor, string statusText, bool markPaused = false)
         {
             StopActiveClip();
             _isPlaying = false;
+            _isPaused = markPaused;
             if (resetCursor)
             {
                 _playbackSeconds = 0.0d;
@@ -286,20 +350,9 @@ namespace GameAudioTool.Editor.Audio
 
         private void DestroyPreviewClips()
         {
-            AudioClip outputClip = _outputClip;
-            AudioClip loopClip = _loopClip;
             _outputClip = null;
             _loopClip = null;
-
-            if (outputClip != null)
-            {
-                UnityEngine.Object.DestroyImmediate(outputClip);
-            }
-
-            if (loopClip != null && loopClip != outputClip)
-            {
-                UnityEngine.Object.DestroyImmediate(loopClip);
-            }
+            _clipAssetCache.Clear();
         }
     }
 }

--- a/Packages/com.example.gameaudiotool/Editor/Audio/GameAudioPreviewState.cs
+++ b/Packages/com.example.gameaudiotool/Editor/Audio/GameAudioPreviewState.cs
@@ -5,6 +5,7 @@ namespace GameAudioTool.Editor.Audio
         public GameAudioPreviewState(
             bool isPreviewReady,
             bool isPlaying,
+            bool isPaused,
             bool loopPlayback,
             double playbackSeconds,
             GameAudioRenderResult renderResult,
@@ -13,6 +14,7 @@ namespace GameAudioTool.Editor.Audio
         {
             IsPreviewReady = isPreviewReady;
             IsPlaying = isPlaying;
+            IsPaused = isPaused;
             LoopPlayback = loopPlayback;
             PlaybackSeconds = playbackSeconds;
             RenderResult = renderResult;
@@ -23,6 +25,8 @@ namespace GameAudioTool.Editor.Audio
         public bool IsPreviewReady { get; }
 
         public bool IsPlaying { get; }
+
+        public bool IsPaused { get; }
 
         public bool LoopPlayback { get; }
 

--- a/Packages/com.example.gameaudiotool/Editor/Audio/GameAudioWavEncoder.cs
+++ b/Packages/com.example.gameaudiotool/Editor/Audio/GameAudioWavEncoder.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+
+namespace GameAudioTool.Editor.Audio
+{
+    internal static class GameAudioWavEncoder
+    {
+        private const short BitsPerSample = 16;
+        private const short BytesPerSample = BitsPerSample / 8;
+
+        public static byte[] EncodePcm16(float[] samples, int sampleRate, int channelCount)
+        {
+            if (samples == null)
+            {
+                throw new ArgumentNullException(nameof(samples));
+            }
+
+            if (sampleRate <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(sampleRate));
+            }
+
+            if (channelCount <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(channelCount));
+            }
+
+            int dataLength = samples.Length * BytesPerSample;
+            int byteRate = sampleRate * channelCount * BytesPerSample;
+            short blockAlign = (short)(channelCount * BytesPerSample);
+
+            using (var stream = new MemoryStream(44 + dataLength))
+            using (var writer = new BinaryWriter(stream))
+            {
+                writer.Write(new[] { 'R', 'I', 'F', 'F' });
+                writer.Write(36 + dataLength);
+                writer.Write(new[] { 'W', 'A', 'V', 'E' });
+                writer.Write(new[] { 'f', 'm', 't', ' ' });
+                writer.Write(16);
+                writer.Write((short)1);
+                writer.Write((short)channelCount);
+                writer.Write(sampleRate);
+                writer.Write(byteRate);
+                writer.Write(blockAlign);
+                writer.Write(BitsPerSample);
+                writer.Write(new[] { 'd', 'a', 't', 'a' });
+                writer.Write(dataLength);
+
+                for (int index = 0; index < samples.Length; index++)
+                {
+                    float clamped = Math.Clamp(samples[index], -1.0f, 1.0f);
+                    short value = (short)Math.Round(clamped * short.MaxValue);
+                    writer.Write(value);
+                }
+
+                writer.Flush();
+                return stream.ToArray();
+            }
+        }
+    }
+}

--- a/Packages/com.example.gameaudiotool/Editor/Audio/GameAudioWavEncoder.cs.meta
+++ b/Packages/com.example.gameaudiotool/Editor/Audio/GameAudioWavEncoder.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1a25d0dca88f4d1428320076427574eb

--- a/Packages/com.example.gameaudiotool/Editor/Windows/GameAudioToolWindow.cs
+++ b/Packages/com.example.gameaudiotool/Editor/Windows/GameAudioToolWindow.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using GameAudioTool.Editor.Application;
 using GameAudioTool.Editor.Audio;
 using GameAudioTool.Editor.Config;
@@ -66,6 +67,7 @@ namespace GameAudioTool.Editor.Windows
 
             rootVisualElement.Add(BuildToolbar());
             rootVisualElement.Add(BuildSummaryPanel());
+            rootVisualElement.Add(BuildSamplePanel());
             rootVisualElement.Add(BuildPreviewPanel());
             rootVisualElement.Add(BuildInfoPanel());
 
@@ -117,6 +119,7 @@ namespace GameAudioTool.Editor.Windows
 
             transportRow.Add(CreateToolbarButton("Render Preview", RenderPreview));
             transportRow.Add(CreateToolbarButton("Play", PlayPreview));
+            transportRow.Add(CreateToolbarButton("Pause", PausePreview));
             transportRow.Add(CreateToolbarButton("Stop", StopPreview));
             transportRow.Add(CreateToolbarButton("Rewind", RewindPreview));
 
@@ -148,6 +151,39 @@ namespace GameAudioTool.Editor.Windows
                 }
             };
             panel.Add(_previewHelpBox);
+
+            return panel;
+        }
+
+        private VisualElement BuildSamplePanel()
+        {
+            var panel = CreateSectionPanel(new Color(0.15f, 0.15f, 0.15f));
+
+            panel.Add(CreateSectionTitle("Samples And Editing"));
+
+            var sampleRow = new VisualElement();
+            sampleRow.style.flexDirection = FlexDirection.Row;
+            sampleRow.style.marginBottom = 8;
+
+            sampleRow.Add(CreateToolbarButton("Create Samples", CreateSampleProjects));
+            sampleRow.Add(CreateToolbarButton("Load Basic SE", LoadBasicSampleProject));
+            sampleRow.Add(CreateToolbarButton("Load Simple Loop", LoadSimpleLoopSampleProject));
+            sampleRow.Add(CreateToolbarButton("Open Folder", OpenSampleProjectsFolder));
+
+            panel.Add(sampleRow);
+
+            var sampleLocationLabel = new Label($"Sample files are stored under {GetUserProjectFolderPath()}");
+            sampleLocationLabel.style.marginBottom = 4;
+            panel.Add(sampleLocationLabel);
+
+            var editingLabel = new Label("Current editing method: timeline and inspector editing UI are not implemented yet. For now, open a .gats.json file and edit the JSON in your text editor, then reopen it in Torus Edison.");
+            editingLabel.style.whiteSpace = WhiteSpace.Normal;
+            editingLabel.style.marginBottom = 4;
+            panel.Add(editingLabel);
+
+            var fieldsLabel = new Label("Useful fields to edit first: project.name, project.bpm, project.totalBars, project.loopPlayback, track volume/pan, note startBeat/durationBeat/midiNote/velocity.");
+            fieldsLabel.style.whiteSpace = WhiteSpace.Normal;
+            panel.Add(fieldsLabel);
 
             return panel;
         }
@@ -267,21 +303,7 @@ namespace GameAudioTool.Editor.Windows
                 return;
             }
 
-            try
-            {
-                GameAudioProjectLoadResult loadResult = _projectSerializer.LoadFromFile(selectedPath);
-                _project = loadResult.Project;
-                _projectPath = selectedPath;
-                _isDirty = false;
-                _loadWarnings = new List<string>(loadResult.Warnings);
-                ResetPreviewState();
-                ShowNotification(new GUIContent("Project loaded."));
-                RefreshView();
-            }
-            catch (Exception exception)
-            {
-                EditorUtility.DisplayDialog(GameAudioToolInfo.DisplayName, exception.Message, "OK");
-            }
+            LoadProjectFromPath(selectedPath);
         }
 
         private void SaveProject()
@@ -400,6 +422,12 @@ namespace GameAudioTool.Editor.Windows
             RefreshView();
         }
 
+        private void PausePreview()
+        {
+            _previewPlaybackService.Pause();
+            RefreshView();
+        }
+
         private void RewindPreview()
         {
             _previewPlaybackService.Rewind();
@@ -425,6 +453,119 @@ namespace GameAudioTool.Editor.Windows
             {
                 RefreshView();
             }
+        }
+
+        private void CreateSampleProjects()
+        {
+            try
+            {
+                EnsureSampleProjects();
+                ShowNotification(new GUIContent("Sample projects created."));
+            }
+            catch (Exception exception)
+            {
+                EditorUtility.DisplayDialog(GameAudioToolInfo.DisplayName, exception.Message, "OK");
+            }
+        }
+
+        private void LoadBasicSampleProject()
+        {
+            LoadSampleProject("BasicSE.gats.json");
+        }
+
+        private void LoadSimpleLoopSampleProject()
+        {
+            LoadSampleProject("SimpleLoop.gats.json");
+        }
+
+        private void OpenSampleProjectsFolder()
+        {
+            try
+            {
+                EnsureSampleProjects();
+                EditorUtility.RevealInFinder(GetUserProjectFolderPath());
+            }
+            catch (Exception exception)
+            {
+                EditorUtility.DisplayDialog(GameAudioToolInfo.DisplayName, exception.Message, "OK");
+            }
+        }
+
+        private void LoadSampleProject(string fileName)
+        {
+            if (!ConfirmDiscardIfDirty())
+            {
+                return;
+            }
+
+            try
+            {
+                EnsureSampleProjects();
+                LoadProjectFromPath(Path.Combine(GetUserProjectFolderPath(), fileName));
+            }
+            catch (Exception exception)
+            {
+                EditorUtility.DisplayDialog(GameAudioToolInfo.DisplayName, exception.Message, "OK");
+            }
+        }
+
+        private void LoadProjectFromPath(string path)
+        {
+            try
+            {
+                GameAudioProjectLoadResult loadResult = _projectSerializer.LoadFromFile(path);
+                _project = loadResult.Project;
+                _projectPath = path;
+                _isDirty = false;
+                _loadWarnings = new List<string>(loadResult.Warnings);
+                ResetPreviewState();
+                ShowNotification(new GUIContent("Project loaded."));
+                RefreshView();
+            }
+            catch (Exception exception)
+            {
+                EditorUtility.DisplayDialog(GameAudioToolInfo.DisplayName, exception.Message, "OK");
+            }
+        }
+
+        private static void EnsureSampleProjects()
+        {
+            string targetDirectory = GetUserProjectFolderPath();
+            Directory.CreateDirectory(targetDirectory);
+
+            CopySampleIfMissing("BasicSE/basic-se.gats.json", Path.Combine(targetDirectory, "BasicSE.gats.json"));
+            CopySampleIfMissing("SimpleLoop/simple-loop.gats.json", Path.Combine(targetDirectory, "SimpleLoop.gats.json"));
+        }
+
+        private static void CopySampleIfMissing(string sampleRelativePath, string targetPath)
+        {
+            if (File.Exists(targetPath))
+            {
+                return;
+            }
+
+            string sourcePath = Path.Combine(GetEmbeddedPackageRootPath(), "Samples~", sampleRelativePath);
+            if (!File.Exists(sourcePath))
+            {
+                throw new FileNotFoundException($"Sample file was not found: {sourcePath}");
+            }
+
+            File.Copy(sourcePath, targetPath, false);
+        }
+
+        private static string GetEmbeddedPackageRootPath()
+        {
+            return Path.Combine(GetProjectRootPath(), "Packages", "com.example.gameaudiotool");
+        }
+
+        private static string GetProjectRootPath()
+        {
+            return Path.GetDirectoryName(UnityEngine.Application.dataPath) ?? Environment.CurrentDirectory;
+        }
+
+        private static string GetUserProjectFolderPath()
+        {
+            return Path.Combine(GetProjectRootPath(), "myAudioProjects");
         }
 
         private void ResetPreviewState()

--- a/Packages/com.example.gameaudiotool/Tests/Editor/GameAudioPreviewCursorCalculatorTests.cs
+++ b/Packages/com.example.gameaudiotool/Tests/Editor/GameAudioPreviewCursorCalculatorTests.cs
@@ -17,6 +17,7 @@ namespace GameAudioTool.Editor.Tests
                 true,
                 false,
                 false,
+                false,
                 0.0d,
                 new GameAudioRenderResult(new float[0], 48000, 2, 48000 * 9, 48000 * 8, 0.0f),
                 "Preview ready.",
@@ -39,6 +40,7 @@ namespace GameAudioTool.Editor.Tests
 
             var previewState = new GameAudioPreviewState(
                 true,
+                false,
                 false,
                 false,
                 8.5d,
@@ -66,9 +68,34 @@ namespace GameAudioTool.Editor.Tests
                 true,
                 true,
                 false,
+                false,
                 2.25d,
                 new GameAudioRenderResult(new float[0], 48000, 2, 48000 * 9, 48000 * 8, 0.0f),
                 "Preview playing.",
+                string.Empty);
+
+            GameAudioPreviewCursorState cursor = GameAudioPreviewCursorCalculator.Calculate(project, previewState);
+
+            Assert.That(cursor.CurrentBar, Is.EqualTo(2));
+            Assert.That(cursor.BeatInBar, Is.EqualTo(1.5d).Within(0.0001d));
+            Assert.That(cursor.MusicalSeconds, Is.EqualTo(2.25d).Within(0.0001d));
+        }
+
+        [Test]
+        public void Calculate_UsesPausedPlaybackPosition()
+        {
+            var project = GameAudioProjectFactory.CreateDefaultProject();
+            project.TotalBars = 4;
+            project.Bpm = 120;
+
+            var previewState = new GameAudioPreviewState(
+                true,
+                false,
+                true,
+                false,
+                2.25d,
+                new GameAudioRenderResult(new float[0], 48000, 2, 48000 * 9, 48000 * 8, 0.0f),
+                "Preview paused.",
                 string.Empty);
 
             GameAudioPreviewCursorState cursor = GameAudioPreviewCursorCalculator.Calculate(project, previewState);


### PR DESCRIPTION
## Summary
- switch preview playback to imported temporary WAV assets so Unity Editor playback is audible
- add Pause support with resume-from-position behavior in the preview transport
- keep sample/local preview cache files out of git noise and extend cursor coverage tests

## Validation
- Unity 6000.4.0f1 temp-copy batch compile succeeded
- manual Unity verification completed for sample playback, Play / Pause / Stop / Rewind / Loop, and preview cursor updates

Closes #4