### PR TITLE
Add snapshot-based undo/redo foundation

### DIFF
--- a/Packages/com.example.gameaudiotool/Editor/Application/GameAudioEditorSession.cs
+++ b/Packages/com.example.gameaudiotool/Editor/Application/GameAudioEditorSession.cs
@@ -1,0 +1,66 @@
+using System;
+using GameAudioTool.Editor.Commands;
+using GameAudioTool.Editor.Domain;
+
+namespace GameAudioTool.Editor.Application
+{
+    public sealed class GameAudioEditorSession
+    {
+        private readonly GameAudioCommandHistory _history;
+
+        public GameAudioEditorSession(GameAudioProject project, int undoHistoryLimit = 100)
+        {
+            CurrentProject = GameAudioProjectCloner.CloneProject(project ?? throw new ArgumentNullException(nameof(project)));
+            _history = new GameAudioCommandHistory(undoHistoryLimit);
+        }
+
+        public GameAudioProject CurrentProject { get; private set; }
+
+        public GameAudioCommandHistory History => _history;
+
+        public bool CanUndo => _history.CanUndo;
+
+        public bool CanRedo => _history.CanRedo;
+
+        public void ReplaceProject(GameAudioProject project, bool clearHistory = true)
+        {
+            CurrentProject = GameAudioProjectCloner.CloneProject(project ?? throw new ArgumentNullException(nameof(project)));
+            if (clearHistory)
+            {
+                _history.Clear();
+            }
+        }
+
+        public void Execute(IGameAudioCommand command)
+        {
+            CurrentProject = _history.Execute(CurrentProject, command ?? throw new ArgumentNullException(nameof(command)));
+        }
+
+        public void Execute(string displayName, Action<GameAudioProject> applyChange)
+        {
+            Execute(GameAudioProjectCommandFactory.CreateMutation(CurrentProject, displayName, applyChange));
+        }
+
+        public bool Undo()
+        {
+            if (!_history.CanUndo)
+            {
+                return false;
+            }
+
+            CurrentProject = _history.Undo(CurrentProject);
+            return true;
+        }
+
+        public bool Redo()
+        {
+            if (!_history.CanRedo)
+            {
+                return false;
+            }
+
+            CurrentProject = _history.Redo(CurrentProject);
+            return true;
+        }
+    }
+}

--- a/Packages/com.example.gameaudiotool/Editor/Application/GameAudioProjectCloner.cs
+++ b/Packages/com.example.gameaudiotool/Editor/Application/GameAudioProjectCloner.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GameAudioTool.Editor.Domain;
+
+namespace GameAudioTool.Editor.Application
+{
+    internal static class GameAudioProjectCloner
+    {
+        public static GameAudioProject CloneProject(GameAudioProject project)
+        {
+            if (project == null)
+            {
+                throw new ArgumentNullException(nameof(project));
+            }
+
+            return new GameAudioProject
+            {
+                Id = project.Id ?? string.Empty,
+                Name = project.Name ?? string.Empty,
+                Bpm = project.Bpm,
+                TimeSignature = CloneTimeSignature(project.TimeSignature),
+                TotalBars = project.TotalBars,
+                SampleRate = project.SampleRate,
+                ChannelMode = project.ChannelMode,
+                MasterGainDb = project.MasterGainDb,
+                LoopPlayback = project.LoopPlayback,
+                Tracks = project.Tracks == null
+                    ? new List<GameAudioTrack>()
+                    : project.Tracks.Select(CloneTrack).ToList()
+            };
+        }
+
+        public static GameAudioTrack CloneTrack(GameAudioTrack track)
+        {
+            if (track == null)
+            {
+                throw new ArgumentNullException(nameof(track));
+            }
+
+            return new GameAudioTrack
+            {
+                Id = track.Id ?? string.Empty,
+                Name = track.Name ?? string.Empty,
+                Mute = track.Mute,
+                Solo = track.Solo,
+                VolumeDb = track.VolumeDb,
+                Pan = track.Pan,
+                DefaultVoice = CloneVoice(track.DefaultVoice),
+                Notes = track.Notes == null
+                    ? new List<GameAudioNote>()
+                    : track.Notes.Select(CloneNote).ToList()
+            };
+        }
+
+        public static GameAudioNote CloneNote(GameAudioNote note)
+        {
+            if (note == null)
+            {
+                throw new ArgumentNullException(nameof(note));
+            }
+
+            return new GameAudioNote
+            {
+                Id = note.Id ?? string.Empty,
+                StartBeat = note.StartBeat,
+                DurationBeat = note.DurationBeat,
+                MidiNote = note.MidiNote,
+                Velocity = note.Velocity,
+                VoiceOverride = note.VoiceOverride == null ? null : CloneVoice(note.VoiceOverride)
+            };
+        }
+
+        private static GameAudioTimeSignature CloneTimeSignature(GameAudioTimeSignature timeSignature)
+        {
+            return timeSignature == null
+                ? new GameAudioTimeSignature()
+                : new GameAudioTimeSignature
+                {
+                    Numerator = timeSignature.Numerator,
+                    Denominator = timeSignature.Denominator
+                };
+        }
+
+        private static GameAudioVoiceSettings CloneVoice(GameAudioVoiceSettings voice)
+        {
+            return voice == null
+                ? GameAudioProjectFactory.CreateDefaultVoice()
+                : new GameAudioVoiceSettings
+                {
+                    Waveform = voice.Waveform,
+                    PulseWidth = voice.PulseWidth,
+                    NoiseEnabled = voice.NoiseEnabled,
+                    NoiseType = voice.NoiseType,
+                    NoiseMix = voice.NoiseMix,
+                    Adsr = CloneEnvelope(voice.Adsr),
+                    Effect = CloneEffect(voice.Effect)
+                };
+        }
+
+        private static GameAudioEnvelopeSettings CloneEnvelope(GameAudioEnvelopeSettings envelope)
+        {
+            return envelope == null
+                ? GameAudioProjectFactory.CreateDefaultEnvelope()
+                : new GameAudioEnvelopeSettings
+                {
+                    AttackMs = envelope.AttackMs,
+                    DecayMs = envelope.DecayMs,
+                    Sustain = envelope.Sustain,
+                    ReleaseMs = envelope.ReleaseMs
+                };
+        }
+
+        private static GameAudioEffectSettings CloneEffect(GameAudioEffectSettings effect)
+        {
+            return effect == null
+                ? GameAudioProjectFactory.CreateDefaultEffect()
+                : new GameAudioEffectSettings
+                {
+                    VolumeDb = effect.VolumeDb,
+                    Pan = effect.Pan,
+                    PitchSemitone = effect.PitchSemitone,
+                    FadeInMs = effect.FadeInMs,
+                    FadeOutMs = effect.FadeOutMs,
+                    Delay = CloneDelay(effect.Delay)
+                };
+        }
+
+        private static GameAudioDelaySettings CloneDelay(GameAudioDelaySettings delay)
+        {
+            return delay == null
+                ? GameAudioProjectFactory.CreateDefaultDelay()
+                : new GameAudioDelaySettings
+                {
+                    Enabled = delay.Enabled,
+                    TimeMs = delay.TimeMs,
+                    Feedback = delay.Feedback,
+                    Mix = delay.Mix
+                };
+        }
+    }
+}

--- a/Packages/com.example.gameaudiotool/Editor/Application/GameAudioProjectCommandFactory.cs
+++ b/Packages/com.example.gameaudiotool/Editor/Application/GameAudioProjectCommandFactory.cs
@@ -1,0 +1,430 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GameAudioTool.Editor.Commands;
+using GameAudioTool.Editor.Domain;
+using GameAudioTool.Editor.Utilities;
+
+namespace GameAudioTool.Editor.Application
+{
+    public static class GameAudioProjectCommandFactory
+    {
+        public static IGameAudioCommand CreateMutation(GameAudioProject sourceProject, string displayName, Action<GameAudioProject> applyChange)
+        {
+            if (sourceProject == null)
+            {
+                throw new ArgumentNullException(nameof(sourceProject));
+            }
+
+            if (string.IsNullOrWhiteSpace(displayName))
+            {
+                throw new ArgumentException("Display name is required.", nameof(displayName));
+            }
+
+            if (applyChange == null)
+            {
+                throw new ArgumentNullException(nameof(applyChange));
+            }
+
+            GameAudioProject afterProject = GameAudioProjectCloner.CloneProject(sourceProject);
+            applyChange(afterProject);
+            NormalizeProject(afterProject);
+            return new GameAudioProjectSnapshotCommand(displayName, sourceProject, afterProject);
+        }
+
+        public static IGameAudioCommand AddNote(GameAudioProject sourceProject, string trackId, GameAudioNote note, int? insertIndex = null)
+        {
+            return CreateMutation(sourceProject, "Add Note", project =>
+            {
+                GameAudioTrack track = RequireTrack(project, trackId);
+                GameAudioNote noteClone = GameAudioProjectCloner.CloneNote(note ?? throw new ArgumentNullException(nameof(note)));
+                noteClone.Id = EnsureId(noteClone.Id, "note");
+                NormalizeNote(noteClone);
+
+                if (insertIndex.HasValue)
+                {
+                    int clampedIndex = Math.Max(0, Math.Min(insertIndex.Value, track.Notes.Count));
+                    track.Notes.Insert(clampedIndex, noteClone);
+                }
+                else
+                {
+                    track.Notes.Add(noteClone);
+                    SortNotes(track.Notes);
+                }
+            });
+        }
+
+        public static IGameAudioCommand RemoveNote(GameAudioProject sourceProject, string trackId, string noteId)
+        {
+            return CreateMutation(sourceProject, "Remove Note", project =>
+            {
+                GameAudioTrack track = RequireTrack(project, trackId);
+                int noteIndex = track.Notes.FindIndex(note => string.Equals(note.Id, noteId, StringComparison.Ordinal));
+                if (noteIndex < 0)
+                {
+                    throw new InvalidOperationException($"Note '{noteId}' was not found in track '{trackId}'.");
+                }
+
+                track.Notes.RemoveAt(noteIndex);
+            });
+        }
+
+        public static IGameAudioCommand MoveNote(GameAudioProject sourceProject, string noteId, string destinationTrackId, float startBeat)
+        {
+            return CreateMutation(sourceProject, "Move Note", project =>
+            {
+                NoteLocation location = RequireNote(project, noteId);
+                GameAudioTrack destinationTrack = RequireTrack(project, destinationTrackId);
+                GameAudioNote note = location.Note;
+
+                location.Track.Notes.RemoveAt(location.NoteIndex);
+                note.StartBeat = startBeat;
+                NormalizeNote(note);
+                destinationTrack.Notes.Add(note);
+                SortNotes(destinationTrack.Notes);
+                if (!ReferenceEquals(location.Track, destinationTrack))
+                {
+                    SortNotes(location.Track.Notes);
+                }
+            });
+        }
+
+        public static IGameAudioCommand ResizeNote(GameAudioProject sourceProject, string noteId, float durationBeat)
+        {
+            return ChangeNotes(sourceProject, new[] { noteId }, "Resize Note", note =>
+            {
+                note.DurationBeat = durationBeat;
+            });
+        }
+
+        public static IGameAudioCommand DuplicateNotes(GameAudioProject sourceProject, IReadOnlyCollection<string> noteIds, float startBeatOffset)
+        {
+            HashSet<string> ids = NormalizeIds(noteIds, nameof(noteIds));
+
+            return CreateMutation(sourceProject, "Duplicate Notes", project =>
+            {
+                bool anyNoteMatched = false;
+                foreach (GameAudioTrack track in project.Tracks)
+                {
+                    var duplicates = new List<GameAudioNote>();
+                    foreach (GameAudioNote note in track.Notes)
+                    {
+                        if (!ids.Contains(note.Id))
+                        {
+                            continue;
+                        }
+
+                        anyNoteMatched = true;
+                        GameAudioNote clone = GameAudioProjectCloner.CloneNote(note);
+                        clone.Id = EnsureId(null, "note");
+                        clone.StartBeat += startBeatOffset;
+                        NormalizeNote(clone);
+                        duplicates.Add(clone);
+                    }
+
+                    if (duplicates.Count > 0)
+                    {
+                        track.Notes.AddRange(duplicates);
+                        SortNotes(track.Notes);
+                    }
+                }
+
+                if (!anyNoteMatched)
+                {
+                    throw new InvalidOperationException("No notes were found for duplication.");
+                }
+            });
+        }
+
+        public static IGameAudioCommand ChangeNotes(GameAudioProject sourceProject, IReadOnlyCollection<string> noteIds, string displayName, Action<GameAudioNote> applyChange)
+        {
+            HashSet<string> ids = NormalizeIds(noteIds, nameof(noteIds));
+
+            return CreateMutation(sourceProject, displayName, project =>
+            {
+                bool anyNoteMatched = false;
+                foreach (GameAudioTrack track in project.Tracks)
+                {
+                    bool trackChanged = false;
+                    foreach (GameAudioNote note in track.Notes)
+                    {
+                        if (!ids.Contains(note.Id))
+                        {
+                            continue;
+                        }
+
+                        applyChange(note);
+                        NormalizeNote(note);
+                        anyNoteMatched = true;
+                        trackChanged = true;
+                    }
+
+                    if (trackChanged)
+                    {
+                        SortNotes(track.Notes);
+                    }
+                }
+
+                if (!anyNoteMatched)
+                {
+                    throw new InvalidOperationException("No notes were found for the requested change.");
+                }
+            });
+        }
+
+        public static IGameAudioCommand AddTrack(GameAudioProject sourceProject, GameAudioTrack track, int? insertIndex = null)
+        {
+            return CreateMutation(sourceProject, "Add Track", project =>
+            {
+                if (project.Tracks.Count >= GameAudioToolInfo.MaxTrackCount)
+                {
+                    throw new InvalidOperationException($"Track count cannot exceed {GameAudioToolInfo.MaxTrackCount}.");
+                }
+
+                GameAudioTrack trackClone = GameAudioProjectCloner.CloneTrack(track ?? throw new ArgumentNullException(nameof(track)));
+                trackClone.Id = EnsureId(trackClone.Id, "track");
+                NormalizeTrack(trackClone, project.Tracks.Count + 1);
+
+                if (insertIndex.HasValue)
+                {
+                    int clampedIndex = Math.Max(0, Math.Min(insertIndex.Value, project.Tracks.Count));
+                    project.Tracks.Insert(clampedIndex, trackClone);
+                }
+                else
+                {
+                    project.Tracks.Add(trackClone);
+                }
+            });
+        }
+
+        public static IGameAudioCommand RemoveTrack(GameAudioProject sourceProject, string trackId)
+        {
+            return CreateMutation(sourceProject, "Remove Track", project =>
+            {
+                int trackIndex = project.Tracks.FindIndex(track => string.Equals(track.Id, trackId, StringComparison.Ordinal));
+                if (trackIndex < 0)
+                {
+                    throw new InvalidOperationException($"Track '{trackId}' was not found.");
+                }
+
+                project.Tracks.RemoveAt(trackIndex);
+            });
+        }
+
+        public static IGameAudioCommand ChangeTracks(GameAudioProject sourceProject, IReadOnlyCollection<string> trackIds, string displayName, Action<GameAudioTrack> applyChange)
+        {
+            HashSet<string> ids = NormalizeIds(trackIds, nameof(trackIds));
+
+            return CreateMutation(sourceProject, displayName, project =>
+            {
+                bool anyTrackMatched = false;
+                for (int index = 0; index < project.Tracks.Count; index++)
+                {
+                    GameAudioTrack track = project.Tracks[index];
+                    if (!ids.Contains(track.Id))
+                    {
+                        continue;
+                    }
+
+                    applyChange(track);
+                    NormalizeTrack(track, index + 1);
+                    anyTrackMatched = true;
+                }
+
+                if (!anyTrackMatched)
+                {
+                    throw new InvalidOperationException("No tracks were found for the requested change.");
+                }
+            });
+        }
+
+        public static IGameAudioCommand ChangeProject(GameAudioProject sourceProject, string displayName, Action<GameAudioProject> applyChange)
+        {
+            return CreateMutation(sourceProject, displayName, applyChange);
+        }
+
+        private static GameAudioTrack RequireTrack(GameAudioProject project, string trackId)
+        {
+            GameAudioTrack track = project.Tracks.FirstOrDefault(candidate => string.Equals(candidate.Id, trackId, StringComparison.Ordinal));
+            if (track == null)
+            {
+                throw new InvalidOperationException($"Track '{trackId}' was not found.");
+            }
+
+            return track;
+        }
+
+        private static NoteLocation RequireNote(GameAudioProject project, string noteId)
+        {
+            foreach (GameAudioTrack track in project.Tracks)
+            {
+                for (int noteIndex = 0; noteIndex < track.Notes.Count; noteIndex++)
+                {
+                    GameAudioNote note = track.Notes[noteIndex];
+                    if (string.Equals(note.Id, noteId, StringComparison.Ordinal))
+                    {
+                        return new NoteLocation(track, note, noteIndex);
+                    }
+                }
+            }
+
+            throw new InvalidOperationException($"Note '{noteId}' was not found.");
+        }
+
+        private static HashSet<string> NormalizeIds(IReadOnlyCollection<string> ids, string paramName)
+        {
+            if (ids == null)
+            {
+                throw new ArgumentNullException(paramName);
+            }
+
+            var normalized = new HashSet<string>(ids.Where(id => !string.IsNullOrWhiteSpace(id)), StringComparer.Ordinal);
+            if (normalized.Count == 0)
+            {
+                throw new ArgumentException("At least one id is required.", paramName);
+            }
+
+            return normalized;
+        }
+
+        private static void NormalizeProject(GameAudioProject project)
+        {
+            project.Id = EnsureId(project.Id, "proj");
+            project.Name = string.IsNullOrWhiteSpace(project.Name) ? "New Audio Project" : project.Name.Trim();
+            project.Bpm = Math.Max(1, project.Bpm);
+            project.TotalBars = Math.Max(1, project.TotalBars);
+            project.SampleRate = GameAudioValidationUtility.IsSupportedSampleRate(project.SampleRate)
+                ? project.SampleRate
+                : GameAudioToolInfo.DefaultSampleRate;
+            project.ChannelMode = project.ChannelMode == GameAudioChannelMode.Mono
+                ? GameAudioChannelMode.Mono
+                : GameAudioChannelMode.Stereo;
+            project.MasterGainDb = GameAudioValidationUtility.ClampFloat(project.MasterGainDb, -24.0f, 6.0f);
+            project.TimeSignature = NormalizeTimeSignature(project.TimeSignature);
+            project.Tracks = project.Tracks ?? new List<GameAudioTrack>();
+
+            for (int index = 0; index < project.Tracks.Count; index++)
+            {
+                NormalizeTrack(project.Tracks[index], index + 1);
+            }
+        }
+
+        private static void NormalizeTrack(GameAudioTrack track, int trackIndex)
+        {
+            track.Id = EnsureId(track.Id, "track");
+            track.Name = string.IsNullOrWhiteSpace(track.Name) ? $"Track {trackIndex:00}" : track.Name.Trim();
+            track.VolumeDb = GameAudioValidationUtility.ClampFloat(track.VolumeDb, -48.0f, 6.0f);
+            track.Pan = GameAudioValidationUtility.ClampFloat(track.Pan, -1.0f, 1.0f);
+            track.DefaultVoice = NormalizeVoice(track.DefaultVoice);
+            track.Notes = track.Notes ?? new List<GameAudioNote>();
+
+            foreach (GameAudioNote note in track.Notes)
+            {
+                NormalizeNote(note);
+            }
+
+            SortNotes(track.Notes);
+        }
+
+        private static void NormalizeNote(GameAudioNote note)
+        {
+            note.Id = EnsureId(note.Id, "note");
+            note.StartBeat = GameAudioValidationUtility.ClampFloat(note.StartBeat, 0.0f, 100000.0f);
+            note.DurationBeat = GameAudioValidationUtility.ClampFloat(note.DurationBeat, GameAudioToolInfo.MinNoteDurationBeat, 100000.0f);
+            note.MidiNote = GameAudioValidationUtility.ClampInt(note.MidiNote, 0, 127);
+            note.Velocity = GameAudioValidationUtility.ClampFloat(note.Velocity, 0.0f, 1.0f);
+            note.VoiceOverride = note.VoiceOverride == null ? null : NormalizeVoice(note.VoiceOverride);
+        }
+
+        private static GameAudioVoiceSettings NormalizeVoice(GameAudioVoiceSettings voice)
+        {
+            GameAudioVoiceSettings normalized = voice ?? GameAudioProjectFactory.CreateDefaultVoice();
+            normalized.PulseWidth = GameAudioValidationUtility.ClampFloat(normalized.PulseWidth, 0.10f, 0.90f);
+            normalized.NoiseMix = GameAudioValidationUtility.ClampFloat(normalized.NoiseMix, 0.0f, 1.0f);
+            normalized.Adsr = NormalizeEnvelope(normalized.Adsr);
+            normalized.Effect = NormalizeEffect(normalized.Effect);
+            return normalized;
+        }
+
+        private static GameAudioEnvelopeSettings NormalizeEnvelope(GameAudioEnvelopeSettings envelope)
+        {
+            GameAudioEnvelopeSettings normalized = envelope ?? GameAudioProjectFactory.CreateDefaultEnvelope();
+            normalized.AttackMs = GameAudioValidationUtility.ClampInt(normalized.AttackMs, 0, 5000);
+            normalized.DecayMs = GameAudioValidationUtility.ClampInt(normalized.DecayMs, 0, 5000);
+            normalized.Sustain = GameAudioValidationUtility.ClampFloat(normalized.Sustain, 0.0f, 1.0f);
+            normalized.ReleaseMs = GameAudioValidationUtility.ClampInt(normalized.ReleaseMs, 0, 5000);
+            return normalized;
+        }
+
+        private static GameAudioEffectSettings NormalizeEffect(GameAudioEffectSettings effect)
+        {
+            GameAudioEffectSettings normalized = effect ?? GameAudioProjectFactory.CreateDefaultEffect();
+            normalized.VolumeDb = GameAudioValidationUtility.ClampFloat(normalized.VolumeDb, -48.0f, 6.0f);
+            normalized.Pan = GameAudioValidationUtility.ClampFloat(normalized.Pan, -1.0f, 1.0f);
+            normalized.PitchSemitone = GameAudioValidationUtility.ClampFloat(normalized.PitchSemitone, -24.0f, 24.0f);
+            normalized.FadeInMs = GameAudioValidationUtility.ClampInt(normalized.FadeInMs, 0, 3000);
+            normalized.FadeOutMs = GameAudioValidationUtility.ClampInt(normalized.FadeOutMs, 0, 3000);
+            normalized.Delay = NormalizeDelay(normalized.Delay);
+            return normalized;
+        }
+
+        private static GameAudioDelaySettings NormalizeDelay(GameAudioDelaySettings delay)
+        {
+            GameAudioDelaySettings normalized = delay ?? GameAudioProjectFactory.CreateDefaultDelay();
+            normalized.TimeMs = GameAudioValidationUtility.ClampInt(normalized.TimeMs, 20, 1000);
+            normalized.Feedback = GameAudioValidationUtility.ClampFloat(normalized.Feedback, 0.0f, 0.70f);
+            normalized.Mix = GameAudioValidationUtility.ClampFloat(normalized.Mix, 0.0f, 1.0f);
+            return normalized;
+        }
+
+        private static GameAudioTimeSignature NormalizeTimeSignature(GameAudioTimeSignature timeSignature)
+        {
+            if (timeSignature == null)
+            {
+                return new GameAudioTimeSignature { Numerator = 4, Denominator = 4 };
+            }
+
+            bool isSupported = (timeSignature.Numerator == 4 && timeSignature.Denominator == 4)
+                || (timeSignature.Numerator == 3 && timeSignature.Denominator == 4)
+                || (timeSignature.Numerator == 6 && timeSignature.Denominator == 8);
+
+            return isSupported
+                ? timeSignature
+                : new GameAudioTimeSignature { Numerator = 4, Denominator = 4 };
+        }
+
+        private static string EnsureId(string currentId, string prefix)
+        {
+            return string.IsNullOrWhiteSpace(currentId)
+                ? $"{prefix}-{Guid.NewGuid():N}"
+                : currentId;
+        }
+
+        private static void SortNotes(List<GameAudioNote> notes)
+        {
+            notes.Sort((left, right) =>
+            {
+                int startComparison = left.StartBeat.CompareTo(right.StartBeat);
+                return startComparison != 0
+                    ? startComparison
+                    : string.Compare(left.Id, right.Id, StringComparison.Ordinal);
+            });
+        }
+
+        private readonly struct NoteLocation
+        {
+            public NoteLocation(GameAudioTrack track, GameAudioNote note, int noteIndex)
+            {
+                Track = track;
+                Note = note;
+                NoteIndex = noteIndex;
+            }
+
+            public GameAudioTrack Track { get; }
+
+            public GameAudioNote Note { get; }
+
+            public int NoteIndex { get; }
+        }
+    }
+}

--- a/Packages/com.example.gameaudiotool/Editor/Commands/GameAudioCommandHistory.cs
+++ b/Packages/com.example.gameaudiotool/Editor/Commands/GameAudioCommandHistory.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using GameAudioTool.Editor.Domain;
+
+namespace GameAudioTool.Editor.Commands
+{
+    public sealed class GameAudioCommandHistory
+    {
+        private readonly int _limit;
+        private readonly List<IGameAudioCommand> _undoCommands = new List<IGameAudioCommand>();
+        private readonly List<IGameAudioCommand> _redoCommands = new List<IGameAudioCommand>();
+
+        public GameAudioCommandHistory(int limit = 100)
+        {
+            if (limit <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(limit));
+            }
+
+            _limit = limit;
+        }
+
+        public int Limit => _limit;
+
+        public int UndoCount => _undoCommands.Count;
+
+        public int RedoCount => _redoCommands.Count;
+
+        public bool CanUndo => _undoCommands.Count > 0;
+
+        public bool CanRedo => _redoCommands.Count > 0;
+
+        public string NextUndoDisplayName => CanUndo
+            ? _undoCommands[_undoCommands.Count - 1].DisplayName
+            : string.Empty;
+
+        public string NextRedoDisplayName => CanRedo
+            ? _redoCommands[_redoCommands.Count - 1].DisplayName
+            : string.Empty;
+
+        public void Clear()
+        {
+            _undoCommands.Clear();
+            _redoCommands.Clear();
+        }
+
+        public GameAudioProject Execute(GameAudioProject currentProject, IGameAudioCommand command)
+        {
+            if (currentProject == null)
+            {
+                throw new ArgumentNullException(nameof(currentProject));
+            }
+
+            if (command == null)
+            {
+                throw new ArgumentNullException(nameof(command));
+            }
+
+            GameAudioProject nextProject = command.Execute(currentProject);
+            PushUndo(command);
+            _redoCommands.Clear();
+            return nextProject;
+        }
+
+        public GameAudioProject Undo(GameAudioProject currentProject)
+        {
+            if (currentProject == null)
+            {
+                throw new ArgumentNullException(nameof(currentProject));
+            }
+
+            if (!CanUndo)
+            {
+                return currentProject;
+            }
+
+            IGameAudioCommand command = PopLast(_undoCommands);
+            GameAudioProject previousProject = command.Undo(currentProject);
+            _redoCommands.Add(command);
+            return previousProject;
+        }
+
+        public GameAudioProject Redo(GameAudioProject currentProject)
+        {
+            if (currentProject == null)
+            {
+                throw new ArgumentNullException(nameof(currentProject));
+            }
+
+            if (!CanRedo)
+            {
+                return currentProject;
+            }
+
+            IGameAudioCommand command = PopLast(_redoCommands);
+            GameAudioProject nextProject = command.Execute(currentProject);
+            PushUndo(command);
+            return nextProject;
+        }
+
+        private void PushUndo(IGameAudioCommand command)
+        {
+            if (_undoCommands.Count >= _limit)
+            {
+                _undoCommands.RemoveAt(0);
+            }
+
+            _undoCommands.Add(command);
+        }
+
+        private static IGameAudioCommand PopLast(List<IGameAudioCommand> commands)
+        {
+            int lastIndex = commands.Count - 1;
+            IGameAudioCommand command = commands[lastIndex];
+            commands.RemoveAt(lastIndex);
+            return command;
+        }
+    }
+}

--- a/Packages/com.example.gameaudiotool/Editor/Commands/GameAudioProjectSnapshotCommand.cs
+++ b/Packages/com.example.gameaudiotool/Editor/Commands/GameAudioProjectSnapshotCommand.cs
@@ -1,0 +1,36 @@
+using System;
+using GameAudioTool.Editor.Application;
+using GameAudioTool.Editor.Domain;
+
+namespace GameAudioTool.Editor.Commands
+{
+    internal sealed class GameAudioProjectSnapshotCommand : IGameAudioCommand
+    {
+        private readonly GameAudioProject _beforeProject;
+        private readonly GameAudioProject _afterProject;
+
+        public GameAudioProjectSnapshotCommand(string displayName, GameAudioProject beforeProject, GameAudioProject afterProject)
+        {
+            if (string.IsNullOrWhiteSpace(displayName))
+            {
+                throw new ArgumentException("Display name is required.", nameof(displayName));
+            }
+
+            _beforeProject = GameAudioProjectCloner.CloneProject(beforeProject ?? throw new ArgumentNullException(nameof(beforeProject)));
+            _afterProject = GameAudioProjectCloner.CloneProject(afterProject ?? throw new ArgumentNullException(nameof(afterProject)));
+            DisplayName = displayName;
+        }
+
+        public string DisplayName { get; }
+
+        public GameAudioProject Execute(GameAudioProject currentProject)
+        {
+            return GameAudioProjectCloner.CloneProject(_afterProject);
+        }
+
+        public GameAudioProject Undo(GameAudioProject currentProject)
+        {
+            return GameAudioProjectCloner.CloneProject(_beforeProject);
+        }
+    }
+}

--- a/Packages/com.example.gameaudiotool/Editor/Commands/IGameAudioCommand.cs
+++ b/Packages/com.example.gameaudiotool/Editor/Commands/IGameAudioCommand.cs
@@ -1,0 +1,13 @@
+using GameAudioTool.Editor.Domain;
+
+namespace GameAudioTool.Editor.Commands
+{
+    public interface IGameAudioCommand
+    {
+        string DisplayName { get; }
+
+        GameAudioProject Execute(GameAudioProject currentProject);
+
+        GameAudioProject Undo(GameAudioProject currentProject);
+    }
+}

--- a/Packages/com.example.gameaudiotool/Tests/Editor/GameAudioCommandHistoryTests.cs
+++ b/Packages/com.example.gameaudiotool/Tests/Editor/GameAudioCommandHistoryTests.cs
@@ -1,0 +1,219 @@
+using System.Linq;
+using GameAudioTool.Editor.Application;
+using GameAudioTool.Editor.Domain;
+using NUnit.Framework;
+
+namespace GameAudioTool.Editor.Tests
+{
+    public sealed class GameAudioCommandHistoryTests
+    {
+        [Test]
+        public void Session_AddNote_UndoAndRedoRoundTrip()
+        {
+            var session = new GameAudioEditorSession(GameAudioProjectFactory.CreateDefaultProject());
+            string trackId = session.CurrentProject.Tracks[0].Id;
+
+            session.Execute(GameAudioProjectCommandFactory.AddNote(
+                session.CurrentProject,
+                trackId,
+                new GameAudioNote
+                {
+                    Id = "note-added",
+                    StartBeat = 1.0f,
+                    DurationBeat = 0.5f,
+                    MidiNote = 72,
+                    Velocity = 0.9f
+                }));
+
+            Assert.That(session.CurrentProject.Tracks[0].Notes.Count, Is.EqualTo(1));
+            Assert.That(session.CanUndo, Is.True);
+            Assert.That(session.History.NextUndoDisplayName, Is.EqualTo("Add Note"));
+
+            Assert.That(session.Undo(), Is.True);
+            Assert.That(session.CurrentProject.Tracks[0].Notes, Is.Empty);
+            Assert.That(session.CanRedo, Is.True);
+
+            Assert.That(session.Redo(), Is.True);
+            Assert.That(session.CurrentProject.Tracks[0].Notes.Count, Is.EqualTo(1));
+            Assert.That(session.CurrentProject.Tracks[0].Notes[0].Id, Is.EqualTo("note-added"));
+        }
+
+        [Test]
+        public void Session_ChangeNotes_TreatsMultipleSelectionAsOneUndoableOperation()
+        {
+            var project = GameAudioProjectFactory.CreateDefaultProject();
+            string trackId = project.Tracks[0].Id;
+            project.Tracks[0].Notes.Add(new GameAudioNote { Id = "note-a", StartBeat = 0.0f, DurationBeat = 1.0f, MidiNote = 60, Velocity = 0.8f });
+            project.Tracks[0].Notes.Add(new GameAudioNote { Id = "note-b", StartBeat = 1.0f, DurationBeat = 1.0f, MidiNote = 64, Velocity = 0.8f });
+
+            var session = new GameAudioEditorSession(project);
+            session.Execute(GameAudioProjectCommandFactory.ChangeNotes(
+                session.CurrentProject,
+                new[] { "note-a", "note-b" },
+                "Transpose Notes",
+                note => note.MidiNote += 12));
+
+            Assert.That(session.CurrentProject.Tracks[0].Notes.Select(note => note.MidiNote).ToArray(), Is.EqualTo(new[] { 72, 76 }));
+            Assert.That(session.History.UndoCount, Is.EqualTo(1));
+
+            Assert.That(session.Undo(), Is.True);
+            Assert.That(session.CurrentProject.Tracks[0].Notes.Select(note => note.MidiNote).ToArray(), Is.EqualTo(new[] { 60, 64 }));
+            Assert.That(session.CurrentProject.Tracks[0].Id, Is.EqualTo(trackId));
+        }
+
+        [Test]
+        public void Session_DuplicateNotes_UndoesAsSingleCommand()
+        {
+            var project = GameAudioProjectFactory.CreateDefaultProject();
+            project.Tracks[0].Notes.Add(new GameAudioNote { Id = "note-a", StartBeat = 0.0f, DurationBeat = 1.0f, MidiNote = 60, Velocity = 0.8f });
+            project.Tracks[0].Notes.Add(new GameAudioNote { Id = "note-b", StartBeat = 2.0f, DurationBeat = 1.0f, MidiNote = 67, Velocity = 0.8f });
+
+            var session = new GameAudioEditorSession(project);
+            session.Execute(GameAudioProjectCommandFactory.DuplicateNotes(session.CurrentProject, new[] { "note-a", "note-b" }, 4.0f));
+
+            GameAudioNote[] notes = session.CurrentProject.Tracks[0].Notes.ToArray();
+            Assert.That(notes.Length, Is.EqualTo(4));
+            Assert.That(notes.Count(note => note.StartBeat >= 4.0f), Is.EqualTo(2));
+            Assert.That(notes.Select(note => note.Id).Distinct().Count(), Is.EqualTo(4));
+
+            Assert.That(session.Undo(), Is.True);
+            Assert.That(session.CurrentProject.Tracks[0].Notes.Select(note => note.Id).ToArray(), Is.EqualTo(new[] { "note-a", "note-b" }));
+        }
+
+        [Test]
+        public void Session_TrackAndProjectCommands_UndoAndRedoSafely()
+        {
+            var session = new GameAudioEditorSession(GameAudioProjectFactory.CreateDefaultProject());
+            string originalTrackId = session.CurrentProject.Tracks[0].Id;
+
+            session.Execute(GameAudioProjectCommandFactory.AddTrack(
+                session.CurrentProject,
+                new GameAudioTrack
+                {
+                    Id = "track-extra",
+                    Name = "Track Extra",
+                    DefaultVoice = GameAudioProjectFactory.CreateDefaultVoice()
+                }));
+
+            session.Execute(GameAudioProjectCommandFactory.ChangeTracks(
+                session.CurrentProject,
+                new[] { "track-extra" },
+                "Mute Track",
+                track =>
+                {
+                    track.Mute = true;
+                    track.Pan = -0.25f;
+                }));
+
+            session.Execute(GameAudioProjectCommandFactory.ChangeProject(
+                session.CurrentProject,
+                "Change Project",
+                project =>
+                {
+                    project.Bpm = 150;
+                    project.LoopPlayback = true;
+                }));
+
+            Assert.That(session.CurrentProject.Tracks.Count, Is.EqualTo(2));
+            Assert.That(session.CurrentProject.Tracks[1].Mute, Is.True);
+            Assert.That(session.CurrentProject.Bpm, Is.EqualTo(150));
+            Assert.That(session.CurrentProject.LoopPlayback, Is.True);
+
+            Assert.That(session.Undo(), Is.True);
+            Assert.That(session.CurrentProject.Bpm, Is.EqualTo(120));
+            Assert.That(session.CurrentProject.LoopPlayback, Is.False);
+
+            Assert.That(session.Undo(), Is.True);
+            Assert.That(session.CurrentProject.Tracks[1].Mute, Is.False);
+            Assert.That(session.CurrentProject.Tracks[1].Pan, Is.EqualTo(0.0f));
+
+            Assert.That(session.Undo(), Is.True);
+            Assert.That(session.CurrentProject.Tracks.Count, Is.EqualTo(1));
+            Assert.That(session.CurrentProject.Tracks[0].Id, Is.EqualTo(originalTrackId));
+
+            Assert.That(session.Redo(), Is.True);
+            Assert.That(session.Redo(), Is.True);
+            Assert.That(session.Redo(), Is.True);
+            Assert.That(session.CurrentProject.Tracks.Count, Is.EqualTo(2));
+            Assert.That(session.CurrentProject.Tracks[1].Mute, Is.True);
+            Assert.That(session.CurrentProject.Bpm, Is.EqualTo(150));
+        }
+
+        [Test]
+        public void Session_MoveResizeRemoveNoteAndRemoveTrack_RoundTrip()
+        {
+            var project = GameAudioProjectFactory.CreateDefaultProject();
+            string firstTrackId = project.Tracks[0].Id;
+            project.Tracks[0].Notes.Add(new GameAudioNote
+            {
+                Id = "note-main",
+                StartBeat = 0.0f,
+                DurationBeat = 1.0f,
+                MidiNote = 60,
+                Velocity = 0.8f
+            });
+
+            var session = new GameAudioEditorSession(project);
+            session.Execute(GameAudioProjectCommandFactory.AddTrack(
+                session.CurrentProject,
+                new GameAudioTrack
+                {
+                    Id = "track-destination",
+                    Name = "Destination",
+                    DefaultVoice = GameAudioProjectFactory.CreateDefaultVoice()
+                }));
+
+            string secondTrackId = session.CurrentProject.Tracks[1].Id;
+
+            session.Execute(GameAudioProjectCommandFactory.MoveNote(session.CurrentProject, "note-main", secondTrackId, 3.5f));
+            Assert.That(session.CurrentProject.Tracks[0].Notes, Is.Empty);
+            Assert.That(session.CurrentProject.Tracks[1].Notes[0].StartBeat, Is.EqualTo(3.5f));
+
+            session.Execute(GameAudioProjectCommandFactory.ResizeNote(session.CurrentProject, "note-main", 2.0f));
+            Assert.That(session.CurrentProject.Tracks[1].Notes[0].DurationBeat, Is.EqualTo(2.0f));
+
+            session.Execute(GameAudioProjectCommandFactory.RemoveNote(session.CurrentProject, secondTrackId, "note-main"));
+            Assert.That(session.CurrentProject.Tracks[1].Notes, Is.Empty);
+
+            Assert.That(session.Undo(), Is.True);
+            Assert.That(session.CurrentProject.Tracks[1].Notes[0].DurationBeat, Is.EqualTo(2.0f));
+
+            Assert.That(session.Undo(), Is.True);
+            Assert.That(session.CurrentProject.Tracks[1].Notes[0].DurationBeat, Is.EqualTo(1.0f));
+
+            Assert.That(session.Undo(), Is.True);
+            Assert.That(session.CurrentProject.Tracks[0].Id, Is.EqualTo(firstTrackId));
+            Assert.That(session.CurrentProject.Tracks[0].Notes[0].Id, Is.EqualTo("note-main"));
+            Assert.That(session.CurrentProject.Tracks[0].Notes[0].StartBeat, Is.EqualTo(0.0f));
+
+            session.Execute(GameAudioProjectCommandFactory.RemoveTrack(session.CurrentProject, secondTrackId));
+            Assert.That(session.CurrentProject.Tracks.Count, Is.EqualTo(1));
+
+            Assert.That(session.Undo(), Is.True);
+            Assert.That(session.CurrentProject.Tracks.Count, Is.EqualTo(2));
+            Assert.That(session.CurrentProject.Tracks[1].Id, Is.EqualTo(secondTrackId));
+        }
+
+        [Test]
+        public void Session_ClearsRedoAfterNewCommandAndRespectsHistoryLimit()
+        {
+            var session = new GameAudioEditorSession(GameAudioProjectFactory.CreateDefaultProject(), 2);
+
+            session.Execute(GameAudioProjectCommandFactory.ChangeProject(session.CurrentProject, "Rename One", project => project.Name = "One"));
+            session.Execute(GameAudioProjectCommandFactory.ChangeProject(session.CurrentProject, "Rename Two", project => project.Name = "Two"));
+            session.Execute(GameAudioProjectCommandFactory.ChangeProject(session.CurrentProject, "Rename Three", project => project.Name = "Three"));
+
+            Assert.That(session.History.UndoCount, Is.EqualTo(2));
+
+            Assert.That(session.Undo(), Is.True);
+            Assert.That(session.CurrentProject.Name, Is.EqualTo("Two"));
+            Assert.That(session.Undo(), Is.True);
+            Assert.That(session.CurrentProject.Name, Is.EqualTo("One"));
+            Assert.That(session.Undo(), Is.False);
+
+            session.Execute(GameAudioProjectCommandFactory.ChangeProject(session.CurrentProject, "Rename Four", project => project.Name = "Four"));
+            Assert.That(session.CanRedo, Is.False);
+            Assert.That(session.CurrentProject.Name, Is.EqualTo("Four"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `GameAudioEditorSession` and `GameAudioCommandHistory` to manage current project state with undo/redo stacks
- add snapshot-based project commands plus typed factories for note, track, and project edits
- add editor tests covering add/remove/move/resize/duplicate, multi-selection changes, redo invalidation, and history limits

## Validation
- Unity 6000.4.0f1 temp-copy batch compile succeeded
- added `GameAudioCommandHistoryTests` for undo/redo behavior coverage
- batch `-runTests -testResults ...` still exited cleanly without writing the XML artifact in this environment

Closes #5