### PR TITLE
[codex] Implement issue #8 WAV export flow

### DIFF
--- a/Packages/com.sunmax.trusedison/Editor/Audio/GameAudioWavExportService.cs
+++ b/Packages/com.sunmax.trusedison/Editor/Audio/GameAudioWavExportService.cs
@@ -1,0 +1,34 @@
+using System;
+using System.IO;
+using TorusEdison.Editor.Domain;
+using TorusEdison.Editor.Utilities;
+
+namespace TorusEdison.Editor.Audio
+{
+    internal sealed class GameAudioWavExportService
+    {
+        private readonly GameAudioProjectRenderer _renderer = new GameAudioProjectRenderer();
+
+        public string Export(GameAudioProject project, string exportDirectory, string projectName)
+        {
+            if (project == null)
+            {
+                throw new ArgumentNullException(nameof(project));
+            }
+
+            string filePath = GameAudioExportUtility.BuildWaveFilePath(exportDirectory, projectName);
+            string directoryPath = Path.GetDirectoryName(filePath);
+            if (string.IsNullOrWhiteSpace(directoryPath))
+            {
+                throw new InvalidOperationException("Export directory could not be resolved.");
+            }
+
+            Directory.CreateDirectory(directoryPath);
+
+            GameAudioRenderResult renderResult = _renderer.Render(project);
+            byte[] wavBytes = GameAudioWavEncoder.EncodePcm16(renderResult.Samples, renderResult.SampleRate, renderResult.ChannelCount);
+            File.WriteAllBytes(filePath, wavBytes);
+            return filePath;
+        }
+    }
+}

--- a/Packages/com.sunmax.trusedison/Editor/Config/GameAudioConfigResolver.cs
+++ b/Packages/com.sunmax.trusedison/Editor/Config/GameAudioConfigResolver.cs
@@ -1,5 +1,5 @@
-using System.IO;
 using TorusEdison.Editor.Domain;
+using TorusEdison.Editor.Utilities;
 
 namespace TorusEdison.Editor.Config
 {
@@ -29,17 +29,15 @@ namespace TorusEdison.Editor.Config
         {
             if (projectConfig != null && !string.IsNullOrWhiteSpace(projectConfig.ExportDirectory))
             {
-                return projectConfig.ExportDirectory;
+                return GameAudioExportUtility.NormalizeExportDirectory(projectConfig.ExportDirectory, projectRoot);
             }
 
             if (commonConfig != null && !string.IsNullOrWhiteSpace(commonConfig.DefaultExportDirectory))
             {
-                return Path.IsPathRooted(commonConfig.DefaultExportDirectory)
-                    ? commonConfig.DefaultExportDirectory
-                    : Path.Combine(projectRoot, commonConfig.DefaultExportDirectory);
+                return GameAudioExportUtility.NormalizeExportDirectory(commonConfig.DefaultExportDirectory, projectRoot);
             }
 
-            return Path.Combine(projectRoot, "Exports", "Audio");
+            return GameAudioExportUtility.NormalizeExportDirectory(string.Empty, projectRoot);
         }
     }
 }

--- a/Packages/com.sunmax.trusedison/Editor/Utilities/GameAudioExportUtility.cs
+++ b/Packages/com.sunmax.trusedison/Editor/Utilities/GameAudioExportUtility.cs
@@ -1,0 +1,63 @@
+using System;
+using System.IO;
+
+namespace TorusEdison.Editor.Utilities
+{
+    internal static class GameAudioExportUtility
+    {
+        public static string NormalizeExportDirectory(string exportDirectory, string projectRoot)
+        {
+            if (string.IsNullOrWhiteSpace(projectRoot))
+            {
+                throw new ArgumentException("Project root is required.", nameof(projectRoot));
+            }
+
+            if (string.IsNullOrWhiteSpace(exportDirectory))
+            {
+                return Path.Combine(projectRoot, "Exports", "Audio");
+            }
+
+            return Path.IsPathRooted(exportDirectory)
+                ? exportDirectory
+                : Path.Combine(projectRoot, exportDirectory);
+        }
+
+        public static string NormalizeWaveFileName(string projectName)
+        {
+            string sanitizedName = GameAudioValidationUtility.SanitizeExportFileName(projectName);
+            if (string.IsNullOrWhiteSpace(sanitizedName))
+            {
+                sanitizedName = "GameAudio";
+            }
+
+            return sanitizedName.EndsWith(".wav", StringComparison.OrdinalIgnoreCase)
+                ? sanitizedName
+                : $"{sanitizedName}.wav";
+        }
+
+        public static string BuildWaveFilePath(string exportDirectory, string projectName)
+        {
+            if (string.IsNullOrWhiteSpace(exportDirectory))
+            {
+                throw new ArgumentException("Export directory is required.", nameof(exportDirectory));
+            }
+
+            return Path.Combine(exportDirectory, NormalizeWaveFileName(projectName));
+        }
+
+        public static bool ShouldRefreshAssetDatabase(string filePath, string projectRoot)
+        {
+            if (string.IsNullOrWhiteSpace(filePath) || string.IsNullOrWhiteSpace(projectRoot))
+            {
+                return false;
+            }
+
+            string fullFilePath = Path.GetFullPath(filePath);
+            string assetsDirectory = Path.GetFullPath(Path.Combine(projectRoot, "Assets"));
+            string assetsDirectoryWithSeparator = assetsDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                + Path.DirectorySeparatorChar;
+
+            return fullFilePath.StartsWith(assetsDirectoryWithSeparator, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/Packages/com.sunmax.trusedison/Editor/Windows/GameAudioToolWindow.cs
+++ b/Packages/com.sunmax.trusedison/Editor/Windows/GameAudioToolWindow.cs
@@ -32,13 +32,17 @@ namespace TorusEdison.Editor.Windows
         private readonly GameAudioPreviewPlaybackService _previewPlaybackService = new GameAudioPreviewPlaybackService();
         private readonly GameAudioProjectSerializer _projectSerializer = new GameAudioProjectSerializer();
         private readonly GameAudioProjectConfigSerializer _projectConfigSerializer = new GameAudioProjectConfigSerializer();
+        private readonly GameAudioWavExportService _wavExportService = new GameAudioWavExportService();
         private readonly HashSet<string> _selectedNoteIds = new HashSet<string>(StringComparer.Ordinal);
 
+        private GameAudioCommonConfig _commonConfig;
+        private GameAudioProjectConfig _projectConfig;
         private GameAudioEditorSession _editorSession;
         private GameAudioProject _project;
         private string _projectPath = string.Empty;
         private bool _isDirty;
         private List<string> _loadWarnings = new List<string>();
+        private string _lastExportedPath = string.Empty;
         private IVisualElementScheduledItem _previewTicker;
         private TimelineDragState _timelineDragState;
         private Vector2 _timelineScrollPosition;
@@ -56,6 +60,12 @@ namespace TorusEdison.Editor.Windows
         private Label _previewBufferValue;
         private Label _previewCursorValue;
         private ProgressBar _previewProgressBar;
+        private TextField _commonExportDirectoryField;
+        private TextField _projectExportDirectoryField;
+        private Toggle _autoRefreshAfterExportToggle;
+        private Label _exportResolvedPathValue;
+        private Label _exportFileNameValue;
+        private Label _exportLastResultValue;
         private IntegerField _toolbarBpmField;
         private PopupField<string> _toolbarGridField;
         private Toggle _toolbarLoopToggle;
@@ -83,8 +93,9 @@ namespace TorusEdison.Editor.Windows
 
         private void CreateGUI()
         {
-            GameAudioCommonConfig commonConfig = _commonConfigSerializer.LoadOrDefault();
-            _currentGridDivision = GameAudioTimelineGridUtility.NormalizeDivision(commonConfig.DefaultGridDivision);
+            _commonConfig = _commonConfigSerializer.LoadOrDefault();
+            _projectConfig = _projectConfigSerializer.LoadOrDefault(GameAudioConfigPaths.GetProjectConfigPath(GetProjectRootPath()));
+            _currentGridDivision = GameAudioTimelineGridUtility.NormalizeDivision(_commonConfig.DefaultGridDivision);
 
             if (_project == null)
             {
@@ -106,8 +117,9 @@ namespace TorusEdison.Editor.Windows
             scrollView.Add(BuildSummaryPanel());
             scrollView.Add(BuildTimelinePanel());
             scrollView.Add(BuildInspectorPanel());
-            scrollView.Add(BuildSamplePanel());
             scrollView.Add(BuildPreviewPanel());
+            scrollView.Add(BuildExportPanel());
+            scrollView.Add(BuildSamplePanel());
             scrollView.Add(BuildInfoPanel());
 
             rootVisualElement.RegisterCallback<KeyDownEvent>(OnRootKeyDown);
@@ -279,6 +291,46 @@ namespace TorusEdison.Editor.Windows
             return panel;
         }
 
+        private VisualElement BuildExportPanel()
+        {
+            var panel = CreateSectionPanel(new Color(0.15f, 0.14f, 0.13f));
+
+            panel.Add(CreateSectionTitle("WAV Export"));
+
+            var actionRow = new VisualElement();
+            actionRow.style.flexDirection = FlexDirection.Row;
+            actionRow.style.alignItems = Align.Center;
+            actionRow.style.flexWrap = Wrap.Wrap;
+            actionRow.style.marginBottom = 8.0f;
+            actionRow.Add(CreateToolbarButton("Export WAV", ExportWav));
+            actionRow.Add(CreateToolbarButton("Open Export Folder", OpenExportFolder));
+            panel.Add(actionRow);
+
+            _exportResolvedPathValue = AddKeyValue(panel, "Resolved Folder");
+            _exportFileNameValue = AddKeyValue(panel, "Export File");
+            _exportLastResultValue = AddKeyValue(panel, "Last Export");
+
+            _commonExportDirectoryField = new TextField
+            {
+                isDelayed = true
+            };
+            _commonExportDirectoryField.RegisterValueChangedCallback(OnCommonExportDirectoryChanged);
+            panel.Add(CreateInspectorRow("Common Default Folder", _commonExportDirectoryField));
+
+            _projectExportDirectoryField = new TextField
+            {
+                isDelayed = true
+            };
+            _projectExportDirectoryField.RegisterValueChangedCallback(OnProjectExportDirectoryChanged);
+            panel.Add(CreateInspectorRow("Project Override Folder", _projectExportDirectoryField));
+
+            _autoRefreshAfterExportToggle = new Toggle();
+            _autoRefreshAfterExportToggle.RegisterValueChangedCallback(OnAutoRefreshAfterExportChanged);
+            panel.Add(CreateInspectorRow("Auto Refresh Assets", _autoRefreshAfterExportToggle));
+
+            return panel;
+        }
+
         private VisualElement BuildSamplePanel()
         {
             var panel = CreateSectionPanel(new Color(0.15f, 0.15f, 0.15f));
@@ -319,11 +371,11 @@ namespace TorusEdison.Editor.Windows
             panel.style.flexDirection = FlexDirection.Column;
 
             panel.Add(CreateSectionTitle("Foundation Status"));
-            var currentScopeLabel = new Label("This window now wires up project creation, timeline note editing, note / track / project inspector editing, Undo / Redo, JSON save/load, offline preview rendering, and editor playback.");
+            var currentScopeLabel = new Label("This window now wires up project creation, timeline note editing, note / track / project inspector editing, Undo / Redo, JSON save/load, offline preview rendering, editor playback, and WAV export.");
             currentScopeLabel.style.marginBottom = 4;
             panel.Add(currentScopeLabel);
 
-            var nextScopeLabel = new Label("WAV export, release validation, and distribution packaging are the next layers to connect.");
+            var nextScopeLabel = new Label("Release validation, documentation sync, and distribution packaging are the next layers to connect.");
             nextScopeLabel.style.marginBottom = 8;
             panel.Add(nextScopeLabel);
 
@@ -1274,12 +1326,138 @@ namespace TorusEdison.Editor.Windows
 
         private GameAudioProject CreateConfiguredProject()
         {
-            GameAudioCommonConfig commonConfig = _commonConfigSerializer.LoadOrDefault();
-            GameAudioProjectConfig projectConfig = _projectConfigSerializer.LoadOrDefault();
-            int sampleRate = GameAudioConfigResolver.ResolveSampleRate(commonConfig, projectConfig);
-            GameAudioChannelMode channelMode = GameAudioConfigResolver.ResolveChannelMode(commonConfig, projectConfig);
-            _currentGridDivision = GameAudioTimelineGridUtility.NormalizeDivision(commonConfig.DefaultGridDivision);
+            _commonConfig ??= _commonConfigSerializer.LoadOrDefault();
+            _projectConfig ??= _projectConfigSerializer.LoadOrDefault(GameAudioConfigPaths.GetProjectConfigPath(GetProjectRootPath()));
+            int sampleRate = GameAudioConfigResolver.ResolveSampleRate(_commonConfig, _projectConfig);
+            GameAudioChannelMode channelMode = GameAudioConfigResolver.ResolveChannelMode(_commonConfig, _projectConfig);
+            _currentGridDivision = GameAudioTimelineGridUtility.NormalizeDivision(_commonConfig.DefaultGridDivision);
             return GameAudioProjectFactory.CreateDefaultProject(sampleRate, channelMode);
+        }
+
+        private string GetResolvedExportDirectory()
+        {
+            _commonConfig ??= _commonConfigSerializer.LoadOrDefault();
+            _projectConfig ??= _projectConfigSerializer.LoadOrDefault(GameAudioConfigPaths.GetProjectConfigPath(GetProjectRootPath()));
+            return GameAudioConfigResolver.ResolveExportDirectory(_commonConfig, _projectConfig, GetProjectRootPath());
+        }
+
+        private void SaveCommonConfig()
+        {
+            _commonConfigSerializer.Save(_commonConfig ?? new GameAudioCommonConfig());
+        }
+
+        private void SaveProjectConfig()
+        {
+            _projectConfigSerializer.Save(
+                _projectConfig ?? new GameAudioProjectConfig(),
+                GameAudioConfigPaths.GetProjectConfigPath(GetProjectRootPath()));
+        }
+
+        private void OnCommonExportDirectoryChanged(ChangeEvent<string> evt)
+        {
+            _commonConfig ??= _commonConfigSerializer.LoadOrDefault();
+            string nextValue = evt.newValue?.Trim() ?? string.Empty;
+            string normalizedValue = string.IsNullOrWhiteSpace(nextValue) ? "Exports/Audio" : nextValue;
+            if (string.Equals(_commonConfig.DefaultExportDirectory, normalizedValue, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            try
+            {
+                _commonConfig.DefaultExportDirectory = normalizedValue;
+                SaveCommonConfig();
+                RefreshView();
+            }
+            catch (Exception exception)
+            {
+                ShowEditorException(exception);
+            }
+        }
+
+        private void OnProjectExportDirectoryChanged(ChangeEvent<string> evt)
+        {
+            _projectConfig ??= _projectConfigSerializer.LoadOrDefault(GameAudioConfigPaths.GetProjectConfigPath(GetProjectRootPath()));
+            string nextValue = evt.newValue?.Trim() ?? string.Empty;
+            if (string.Equals(_projectConfig.ExportDirectory, nextValue, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            try
+            {
+                _projectConfig.ExportDirectory = nextValue;
+                SaveProjectConfig();
+                RefreshView();
+            }
+            catch (Exception exception)
+            {
+                ShowEditorException(exception);
+            }
+        }
+
+        private void OnAutoRefreshAfterExportChanged(ChangeEvent<bool> evt)
+        {
+            _projectConfig ??= _projectConfigSerializer.LoadOrDefault(GameAudioConfigPaths.GetProjectConfigPath(GetProjectRootPath()));
+            if (_projectConfig.AutoRefreshAfterExport == evt.newValue)
+            {
+                return;
+            }
+
+            try
+            {
+                _projectConfig.AutoRefreshAfterExport = evt.newValue;
+                SaveProjectConfig();
+                RefreshView();
+            }
+            catch (Exception exception)
+            {
+                ShowEditorException(exception);
+            }
+        }
+
+        private void ExportWav()
+        {
+            GameAudioProject project = CurrentProject;
+            if (project == null)
+            {
+                return;
+            }
+
+            try
+            {
+                string exportDirectory = GetResolvedExportDirectory();
+                string exportPath = _wavExportService.Export(project, exportDirectory, project.Name);
+                _lastExportedPath = exportPath;
+
+                bool shouldRefresh = (_projectConfig?.AutoRefreshAfterExport ?? true)
+                    && GameAudioExportUtility.ShouldRefreshAssetDatabase(exportPath, GetProjectRootPath());
+                if (shouldRefresh)
+                {
+                    AssetDatabase.Refresh();
+                }
+
+                ShowNotification(new GUIContent(shouldRefresh ? "WAV exported and assets refreshed." : "WAV exported."));
+                RefreshView();
+            }
+            catch (Exception exception)
+            {
+                ShowEditorException(exception);
+            }
+        }
+
+        private void OpenExportFolder()
+        {
+            try
+            {
+                string exportDirectory = GetResolvedExportDirectory();
+                Directory.CreateDirectory(exportDirectory);
+                EditorUtility.RevealInFinder(exportDirectory);
+            }
+            catch (Exception exception)
+            {
+                ShowEditorException(exception);
+            }
         }
 
         private void RenderPreview()
@@ -1557,10 +1735,12 @@ namespace TorusEdison.Editor.Windows
             _projectPath = path ?? string.Empty;
             _isDirty = isDirty;
             _loadWarnings = warnings == null ? new List<string>() : new List<string>(warnings);
-            _editorSession = new GameAudioEditorSession(_project, _commonConfigSerializer.LoadOrDefault().UndoHistoryLimit);
+            _commonConfig ??= _commonConfigSerializer.LoadOrDefault();
+            _editorSession = new GameAudioEditorSession(_project, _commonConfig.UndoHistoryLimit);
             _selectedNoteIds.Clear();
             _selectedTrackId = _project.Tracks.FirstOrDefault()?.Id ?? string.Empty;
             _inspectorStateKey = string.Empty;
+            _lastExportedPath = string.Empty;
             CancelTimelineInteraction();
             _timelineScrollPosition = Vector2.zero;
             ResetPreviewState();
@@ -2280,6 +2460,20 @@ namespace TorusEdison.Editor.Windows
             _toolbarGridField?.SetValueWithoutNotify(GameAudioTimelineGridUtility.NormalizeDivision(_currentGridDivision));
             _toolbarLoopToggle?.SetValueWithoutNotify(project.LoopPlayback);
             _loopToggle.SetValueWithoutNotify(project.LoopPlayback);
+            if (_commonExportDirectoryField != null)
+            {
+                _commonExportDirectoryField.SetValueWithoutNotify(_commonConfig?.DefaultExportDirectory ?? "Exports/Audio");
+            }
+
+            if (_projectExportDirectoryField != null)
+            {
+                _projectExportDirectoryField.SetValueWithoutNotify(_projectConfig?.ExportDirectory ?? string.Empty);
+            }
+
+            _autoRefreshAfterExportToggle?.SetValueWithoutNotify(_projectConfig?.AutoRefreshAfterExport ?? true);
+            _exportResolvedPathValue.text = GetResolvedExportDirectory();
+            _exportFileNameValue.text = GameAudioExportUtility.NormalizeWaveFileName(project.Name);
+            _exportLastResultValue.text = string.IsNullOrWhiteSpace(_lastExportedPath) ? "(not exported)" : _lastExportedPath;
 
             if (_undoButton != null)
             {

--- a/Packages/com.sunmax.trusedison/Tests/Editor/GameAudioExportUtilityTests.cs
+++ b/Packages/com.sunmax.trusedison/Tests/Editor/GameAudioExportUtilityTests.cs
@@ -1,0 +1,119 @@
+using System.IO;
+using System.Text;
+using NUnit.Framework;
+using TorusEdison.Editor.Audio;
+using TorusEdison.Editor.Application;
+using TorusEdison.Editor.Config;
+using TorusEdison.Editor.Domain;
+using TorusEdison.Editor.Utilities;
+
+namespace TorusEdison.Editor.Tests
+{
+    public sealed class GameAudioExportUtilityTests
+    {
+        [Test]
+        public void ResolveExportDirectory_UsesRelativeProjectOverrideWithinProjectRoot()
+        {
+            var commonConfig = new GameAudioCommonConfig
+            {
+                DefaultExportDirectory = "Exports/Common"
+            };
+
+            var projectConfig = new GameAudioProjectConfig
+            {
+                ExportDirectory = "Exports/Project"
+            };
+
+            string resolved = GameAudioConfigResolver.ResolveExportDirectory(commonConfig, projectConfig, "D:/ProjectRoot");
+
+            Assert.That(resolved.Replace('\\', '/'), Is.EqualTo("D:/ProjectRoot/Exports/Project"));
+        }
+
+        [Test]
+        public void BuildWaveFilePath_SanitizesNameAndAppendsExtension()
+        {
+            string path = GameAudioExportUtility.BuildWaveFilePath("D:/Exports", "Boss:SE?");
+
+            Assert.That(path.Replace('\\', '/'), Is.EqualTo("D:/Exports/Boss_SE_.wav"));
+        }
+
+        [Test]
+        public void ShouldRefreshAssetDatabase_ReturnsTrueOnlyForAssetsSubpaths()
+        {
+            Assert.That(GameAudioExportUtility.ShouldRefreshAssetDatabase("D:/Project/Assets/Exports/test.wav", "D:/Project"), Is.True);
+            Assert.That(GameAudioExportUtility.ShouldRefreshAssetDatabase("D:/Project/Exports/test.wav", "D:/Project"), Is.False);
+        }
+
+        [Test]
+        public void EncodePcm16_WritesExpectedWaveHeader()
+        {
+            byte[] wavBytes = GameAudioWavEncoder.EncodePcm16(new[] { -1.0f, 0.0f, 1.0f, 0.5f }, 48000, 2);
+
+            using var stream = new MemoryStream(wavBytes);
+            using var reader = new BinaryReader(stream, Encoding.ASCII);
+
+            string riff = new string(reader.ReadChars(4));
+            int riffChunkSize = reader.ReadInt32();
+            string wave = new string(reader.ReadChars(4));
+            string fmt = new string(reader.ReadChars(4));
+            int fmtChunkSize = reader.ReadInt32();
+            short audioFormat = reader.ReadInt16();
+            short channelCount = reader.ReadInt16();
+            int sampleRate = reader.ReadInt32();
+            int byteRate = reader.ReadInt32();
+            short blockAlign = reader.ReadInt16();
+            short bitsPerSample = reader.ReadInt16();
+            string data = new string(reader.ReadChars(4));
+            int dataLength = reader.ReadInt32();
+
+            Assert.That(riff, Is.EqualTo("RIFF"));
+            Assert.That(riffChunkSize, Is.EqualTo(wavBytes.Length - 8));
+            Assert.That(wave, Is.EqualTo("WAVE"));
+            Assert.That(fmt, Is.EqualTo("fmt "));
+            Assert.That(fmtChunkSize, Is.EqualTo(16));
+            Assert.That(audioFormat, Is.EqualTo(1));
+            Assert.That(channelCount, Is.EqualTo(2));
+            Assert.That(sampleRate, Is.EqualTo(48000));
+            Assert.That(byteRate, Is.EqualTo(192000));
+            Assert.That(blockAlign, Is.EqualTo(4));
+            Assert.That(bitsPerSample, Is.EqualTo(16));
+            Assert.That(data, Is.EqualTo("data"));
+            Assert.That(dataLength, Is.EqualTo(8));
+        }
+
+        [Test]
+        public void Export_WritesWaveFileToDisk()
+        {
+            string root = Path.Combine(Path.GetTempPath(), "TorusEdisonTests", Path.GetRandomFileName());
+
+            try
+            {
+                GameAudioProject project = GameAudioProjectFactory.CreateDefaultProject();
+                project.Tracks[0].Notes.Add(new GameAudioNote
+                {
+                    Id = "note-a",
+                    StartBeat = 0.0f,
+                    DurationBeat = 0.5f,
+                    MidiNote = 72,
+                    Velocity = 0.8f
+                });
+
+                var service = new GameAudioWavExportService();
+                string filePath = service.Export(project, root, "Export:Test");
+
+                Assert.That(File.Exists(filePath), Is.True);
+                byte[] bytes = File.ReadAllBytes(filePath);
+                Assert.That(bytes.Length, Is.GreaterThan(44));
+                Assert.That(Encoding.ASCII.GetString(bytes, 0, 4), Is.EqualTo("RIFF"));
+                Assert.That(Path.GetFileName(filePath), Is.EqualTo("Export_Test.wav"));
+            }
+            finally
+            {
+                if (Directory.Exists(root))
+                {
+                    Directory.Delete(root, true);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a WAV export panel with export buttons, output-folder settings, and auto-refresh control
- resolve export directories through common and project config with relative-path support
- add export utility and service tests including RIFF/WAVE header coverage

## Validation
- Unity 6000.4.0f1 batch compile on a temp validation copy succeeded
- Unity 6000.4.0f1 batch EditMode test run exited with code 0, but Unity still did not emit the requested `-testResults` XML artifact on this environment

## Notes
- Refs #8
- Manual acceptance still needed in the live editor for actual WAV export, output folder settings, and `AssetDatabase.Refresh()` behavior when exporting under `Assets/`
