### PR TITLE
[codex] Implement issue #11 release packaging flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,10 +28,13 @@ Desktop.ini
 # Generated release artifacts
 *.unitypackage
 *.zip
+ReleaseBuilds/
 
 # Editor preview cache
 Assets/__TorusEdisonPreviewCache__/
 Assets/__TorusEdisonPreviewCache__.meta
+Assets/__TorusEdisonReleaseStaging__/
+Assets/__TorusEdisonReleaseStaging__.meta
 
 # Local user projects
 myAudioProjects/

--- a/Packages/com.sunmax.trusedison/CHANGELOG.md
+++ b/Packages/com.sunmax.trusedison/CHANGELOG.md
@@ -8,6 +8,7 @@
 - refreshed the bundled `BasicSE` and `SimpleLoop` sample projects for playback and export checks
 - added release-readiness validation notes, sample guidance, and acceptance-scenario editor tests
 - refreshed README, manuals, release notes, terms, and license documents to match the current implementation
+- added a UnityPackage exporter, release packaging script, and release artifact layout documentation
 
 
 ## 0.1.0

--- a/Packages/com.sunmax.trusedison/Editor/Release.meta
+++ b/Packages/com.sunmax.trusedison/Editor/Release.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2d3dc19868db67a47bc9ce15d09a763e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.sunmax.trusedison/Editor/Release/TorusEdisonReleaseBuilder.cs
+++ b/Packages/com.sunmax.trusedison/Editor/Release/TorusEdisonReleaseBuilder.cs
@@ -1,0 +1,146 @@
+using System;
+using System.IO;
+using UnityEditor;
+
+namespace TorusEdison.Editor.Release
+{
+    internal static class TorusEdisonReleaseBuilder
+    {
+        private const string PackageRoot = "Packages/com.sunmax.trusedison";
+        private const string StageRoot = "Assets/__TorusEdisonReleaseStaging__";
+        private const string StageToolRoot = StageRoot + "/TorusEdison";
+
+        [MenuItem("Tools/Torus Edison/Build Release UnityPackage")]
+        private static void BuildUnityPackageInteractive()
+        {
+            PackageManifest manifest = LoadManifest();
+            string outputPath = EditorUtility.SaveFilePanel(
+                "Build Torus Edison UnityPackage",
+                Path.GetFullPath(Path.Combine(UnityEngine.Application.dataPath, "..")),
+                $"TorusEdison-{manifest.version}",
+                "unitypackage");
+
+            if (string.IsNullOrWhiteSpace(outputPath))
+            {
+                return;
+            }
+
+            BuildUnityPackage(outputPath);
+            EditorUtility.RevealInFinder(outputPath);
+        }
+
+        public static void BuildUnityPackageBatch()
+        {
+            string outputPath = Environment.GetEnvironmentVariable("TORUS_EDISON_UNITYPACKAGE_OUTPUT");
+            if (string.IsNullOrWhiteSpace(outputPath))
+            {
+                throw new InvalidOperationException("TORUS_EDISON_UNITYPACKAGE_OUTPUT is required.");
+            }
+
+            BuildUnityPackage(outputPath);
+        }
+
+        internal static void BuildUnityPackage(string outputPath)
+        {
+            string normalizedOutputPath = NormalizeUnityPackagePath(outputPath);
+
+            try
+            {
+                CleanupStageRoot();
+                CopyDirectoryContents(ProjectToAbsolutePath($"{PackageRoot}/Editor"), ProjectToAbsolutePath($"{StageToolRoot}/Editor"));
+                CopyDirectoryContents(ProjectToAbsolutePath($"{PackageRoot}/Documentation~"), ProjectToAbsolutePath($"{StageToolRoot}/Documentation"));
+                CopyDirectoryContents(ProjectToAbsolutePath($"{PackageRoot}/Samples~"), ProjectToAbsolutePath($"{StageToolRoot}/Samples"));
+                CopyFile(ProjectToAbsolutePath($"{PackageRoot}/CHANGELOG.md"), ProjectToAbsolutePath($"{StageToolRoot}/CHANGELOG.md"));
+                CopyFile(ProjectToAbsolutePath($"{PackageRoot}/LICENSE.md"), ProjectToAbsolutePath($"{StageToolRoot}/LICENSE.md"));
+
+                AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport);
+
+                string outputDirectory = Path.GetDirectoryName(normalizedOutputPath);
+                if (string.IsNullOrWhiteSpace(outputDirectory))
+                {
+                    throw new InvalidOperationException("UnityPackage output directory could not be resolved.");
+                }
+
+                Directory.CreateDirectory(outputDirectory);
+                AssetDatabase.ExportPackage(StageRoot, normalizedOutputPath, ExportPackageOptions.Recurse);
+                UnityEngine.Debug.Log($"Torus Edison unitypackage exported to: {normalizedOutputPath}");
+            }
+            finally
+            {
+                CleanupStageRoot();
+            }
+        }
+
+        private static void CleanupStageRoot()
+        {
+            FileUtil.DeleteFileOrDirectory(StageRoot);
+            FileUtil.DeleteFileOrDirectory($"{StageRoot}.meta");
+            AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport);
+        }
+
+        private static void CopyDirectoryContents(string sourceRoot, string destinationRoot)
+        {
+            Directory.CreateDirectory(destinationRoot);
+
+            foreach (string sourceFile in Directory.GetFiles(sourceRoot, "*", SearchOption.AllDirectories))
+            {
+                if (sourceFile.EndsWith(".meta", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                string relativePath = Path.GetRelativePath(sourceRoot, sourceFile);
+                string destinationFile = Path.Combine(destinationRoot, relativePath);
+                string destinationDirectory = Path.GetDirectoryName(destinationFile);
+                if (!string.IsNullOrWhiteSpace(destinationDirectory))
+                {
+                    Directory.CreateDirectory(destinationDirectory);
+                }
+
+                File.Copy(sourceFile, destinationFile, true);
+            }
+        }
+
+        private static void CopyFile(string sourceFile, string destinationFile)
+        {
+            string destinationDirectory = Path.GetDirectoryName(destinationFile);
+            if (!string.IsNullOrWhiteSpace(destinationDirectory))
+            {
+                Directory.CreateDirectory(destinationDirectory);
+            }
+
+            File.Copy(sourceFile, destinationFile, true);
+        }
+
+        private static string ProjectToAbsolutePath(string projectRelativePath)
+        {
+            return Path.GetFullPath(Path.Combine(UnityEngine.Application.dataPath, "..", projectRelativePath.Replace('/', Path.DirectorySeparatorChar)));
+        }
+
+        private static string NormalizeUnityPackagePath(string path)
+        {
+            string normalized = Path.GetFullPath(path);
+            return normalized.EndsWith(".unitypackage", StringComparison.OrdinalIgnoreCase)
+                ? normalized
+                : $"{normalized}.unitypackage";
+        }
+
+        private static PackageManifest LoadManifest()
+        {
+            string json = File.ReadAllText(ProjectToAbsolutePath($"{PackageRoot}/package.json"));
+            PackageManifest manifest = UnityEngine.JsonUtility.FromJson<PackageManifest>(json);
+            if (manifest == null || string.IsNullOrWhiteSpace(manifest.version))
+            {
+                throw new InvalidOperationException("Package manifest version could not be read.");
+            }
+
+            return manifest;
+        }
+
+        [Serializable]
+        private sealed class PackageManifest
+        {
+            public string version;
+        }
+    }
+}

--- a/Packages/com.sunmax.trusedison/Editor/Release/TorusEdisonReleaseBuilder.cs.meta
+++ b/Packages/com.sunmax.trusedison/Editor/Release/TorusEdisonReleaseBuilder.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 18d5af4b654fdee4ebebf9cec75d1daa

--- a/tools/release/README.md
+++ b/tools/release/README.md
@@ -1,0 +1,56 @@
+# Torus Edison Release Packaging
+
+## Goal
+
+This folder defines the repeatable flow for building the release artifacts that will later be attached to GitHub Release and mirrored to BOOTH.
+
+## Fixed Artifact Names
+
+The current release flow uses these names:
+
+- unitypackage: `TorusEdison-<version>.unitypackage`
+- release zip: `TorusEdison-<version>-release.zip`
+- staging folder: `ReleaseBuilds/TorusEdison-<version>/`
+
+## Release Zip Contents
+
+The release zip is expected to contain:
+
+- `README.md`
+- `Manual.ja.md`
+- `Manual.md`
+- `TermsOfUse.md`
+- `ReleaseNotes.md`
+- `ValidationChecklist.md`
+- `CHANGELOG.md`
+- `LICENSE.md`
+- `Samples/BasicSE.gats.json`
+- `Samples/SimpleLoop.gats.json`
+- `TorusEdison-<version>.unitypackage`
+
+## Build Command
+
+Run from the repository root:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File tools\release\build-release.ps1
+```
+
+Optional parameters:
+
+- `-UnityPath` to point at a specific Unity executable
+- `-ProjectPath` to point at a specific host project
+- `-OutputRoot` to change the artifact output directory
+- `-SkipUnityPackage` to rebuild the zip contents without calling Unity
+
+## Release Checklist
+
+Before attaching the zip to GitHub Release:
+
+1. Confirm the package version in `Packages/com.sunmax.trusedison/package.json`
+2. Confirm `README`, manuals, terms, release notes, and changelog match the current implementation
+3. Run the validation checklist in `Packages/com.sunmax.trusedison/Documentation~/ValidationChecklist.md`
+4. Run `tools/release/build-release.ps1`
+5. Confirm the unitypackage and zip were both created
+6. Open the zip and verify the expected files are present
+7. Keep the GitHub Release artifact and BOOTH artifact identical

--- a/tools/release/build-release.ps1
+++ b/tools/release/build-release.ps1
@@ -1,0 +1,123 @@
+param(
+    [string]$UnityPath = "C:\Program Files\Unity\6000.4.0f1\Editor\Unity.exe",
+    [string]$ProjectPath = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path,
+    [string]$OutputRoot = "",
+    [switch]$SkipUnityPackage
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path -LiteralPath $UnityPath)) {
+    throw "Unity executable was not found: $UnityPath"
+}
+
+$projectPath = (Resolve-Path $ProjectPath).Path
+$packageRoot = Join-Path $projectPath "Packages\com.sunmax.trusedison"
+$packageManifestPath = Join-Path $packageRoot "package.json"
+
+if (-not (Test-Path -LiteralPath $packageManifestPath)) {
+    throw "package.json was not found: $packageManifestPath"
+}
+
+$packageManifest = Get-Content -Raw -Encoding utf8 $packageManifestPath | ConvertFrom-Json
+$version = $packageManifest.version
+$toolName = "TorusEdison"
+
+if ([string]::IsNullOrWhiteSpace($version)) {
+    throw "Package version could not be read from package.json."
+}
+
+if ([string]::IsNullOrWhiteSpace($OutputRoot)) {
+    $OutputRoot = Join-Path $projectPath "ReleaseBuilds"
+}
+
+$outputRoot = [System.IO.Path]::GetFullPath($OutputRoot)
+$stageRoot = Join-Path $outputRoot "$toolName-$version"
+$samplesRoot = Join-Path $stageRoot "Samples"
+$unityPackagePath = Join-Path $stageRoot "$toolName-$version.unitypackage"
+$zipPath = Join-Path $outputRoot "$toolName-$version-release.zip"
+$manifestPath = Join-Path $stageRoot "release-manifest.txt"
+
+if (Test-Path -LiteralPath $stageRoot) {
+    Remove-Item -LiteralPath $stageRoot -Recurse -Force
+}
+
+New-Item -ItemType Directory -Path $stageRoot | Out-Null
+New-Item -ItemType Directory -Path $samplesRoot | Out-Null
+
+if (-not $SkipUnityPackage) {
+    $env:TORUS_EDISON_UNITYPACKAGE_OUTPUT = $unityPackagePath
+    try {
+        $logPath = Join-Path $outputRoot "$toolName-$version-unitypackage.log"
+        if (Test-Path -LiteralPath $logPath) {
+            Remove-Item -LiteralPath $logPath -Force
+        }
+
+        $process = Start-Process -FilePath $UnityPath `
+            -WorkingDirectory $projectPath `
+            -ArgumentList @(
+                "-batchmode",
+                "-quit",
+                "-nographics",
+                "-projectPath", $projectPath,
+                "-executeMethod", "TorusEdison.Editor.Release.TorusEdisonReleaseBuilder.BuildUnityPackageBatch",
+                "-logFile", $logPath
+            ) `
+            -Wait `
+            -PassThru
+
+        if ($process.ExitCode -ne 0) {
+            throw "Unity batch build failed with exit code $($process.ExitCode). See $logPath"
+        }
+    }
+    finally {
+        Remove-Item Env:TORUS_EDISON_UNITYPACKAGE_OUTPUT -ErrorAction SilentlyContinue
+    }
+}
+
+Copy-Item -LiteralPath (Join-Path $projectPath "README.md") -Destination (Join-Path $stageRoot "README.md")
+Copy-Item -LiteralPath (Join-Path $packageRoot "Documentation~\Manual.ja.md") -Destination (Join-Path $stageRoot "Manual.ja.md")
+Copy-Item -LiteralPath (Join-Path $packageRoot "Documentation~\Manual.md") -Destination (Join-Path $stageRoot "Manual.md")
+Copy-Item -LiteralPath (Join-Path $packageRoot "Documentation~\TermsOfUse.md") -Destination (Join-Path $stageRoot "TermsOfUse.md")
+Copy-Item -LiteralPath (Join-Path $packageRoot "Documentation~\ReleaseNotes.md") -Destination (Join-Path $stageRoot "ReleaseNotes.md")
+Copy-Item -LiteralPath (Join-Path $packageRoot "Documentation~\ValidationChecklist.md") -Destination (Join-Path $stageRoot "ValidationChecklist.md")
+Copy-Item -LiteralPath (Join-Path $packageRoot "CHANGELOG.md") -Destination (Join-Path $stageRoot "CHANGELOG.md")
+Copy-Item -LiteralPath (Join-Path $packageRoot "LICENSE.md") -Destination (Join-Path $stageRoot "LICENSE.md")
+Copy-Item -LiteralPath (Join-Path $packageRoot "Samples~\BasicSE\basic-se.gats.json") -Destination (Join-Path $samplesRoot "BasicSE.gats.json")
+Copy-Item -LiteralPath (Join-Path $packageRoot "Samples~\SimpleLoop\simple-loop.gats.json") -Destination (Join-Path $samplesRoot "SimpleLoop.gats.json")
+
+$manifestLines = @(
+    "Tool: $toolName",
+    "Version: $version",
+    "UnityPackage: $(Split-Path -Leaf $unityPackagePath)",
+    "Zip: $(Split-Path -Leaf $zipPath)",
+    "Contents:",
+    "- README.md",
+    "- Manual.ja.md",
+    "- Manual.md",
+    "- TermsOfUse.md",
+    "- ReleaseNotes.md",
+    "- ValidationChecklist.md",
+    "- CHANGELOG.md",
+    "- LICENSE.md",
+    "- Samples/BasicSE.gats.json",
+    "- Samples/SimpleLoop.gats.json"
+)
+
+if (-not $SkipUnityPackage) {
+    $manifestLines += "- $(Split-Path -Leaf $unityPackagePath)"
+}
+
+Set-Content -LiteralPath $manifestPath -Encoding utf8 -Value $manifestLines
+
+if (Test-Path -LiteralPath $zipPath) {
+    Remove-Item -LiteralPath $zipPath -Force
+}
+
+Compress-Archive -Path (Join-Path $stageRoot "*") -DestinationPath $zipPath -CompressionLevel Optimal
+
+Write-Output "Release stage: $stageRoot"
+Write-Output "Release zip: $zipPath"
+if (-not $SkipUnityPackage) {
+    Write-Output "UnityPackage: $unityPackagePath"
+}


### PR DESCRIPTION
## Summary
- add a Unity batch callable release builder that stages the package into `Assets/` and exports a `unitypackage`
- add a PowerShell release script that assembles the fixed GitHub Release zip layout with manuals, terms, release notes, validation docs, samples, changelog, license, and the unitypackage
- document the release artifact names and release checklist, and ignore generated release staging output in git

## Validation
- Unity 6000.4.0f1 temp-copy batch compile succeeded with the new release builder
- `tools/release/build-release.ps1` succeeded on a temp validation copy
- validated generated artifacts:
  - `TorusEdison-0.1.0.unitypackage`
  - `TorusEdison-0.1.0-release.zip`
  - expected zip contents were present

## Notes
- unrelated local differences under `ProjectSettings/*`, legacy `.meta` paths, and `Assets/success.mp3` were intentionally left out of this PR

Closes #11