### PR TITLE
[codex] Add release publication texts for issue #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 この README は概要案内です。詳しい使い方や画面ごとの説明は、以下のドキュメントをご確認ください。
 
+- GitHub Release 配布ページ: https://github.com/Sunmax0731/SoundCreater/releases
 - 使い方マニュアル 日本語版: [Manual.ja.md](Packages/com.sunmax.trusedison/Documentation~/Manual.ja.md)
 - 使い方マニュアル 英語版: [Manual.md](Packages/com.sunmax.trusedison/Documentation~/Manual.md)
 - 利用規約: [TermsOfUse.md](Packages/com.sunmax.trusedison/Documentation~/TermsOfUse.md)

--- a/tools/release/BOOTHDescription.ja.md
+++ b/tools/release/BOOTHDescription.ja.md
@@ -1,0 +1,52 @@
+# Torus Edison
+
+Unity Editor 上で、ゲーム用の簡単な効果音やループを作成するためのエディタ拡張です。  
+`.gats.json` で音声プロジェクトを保存し、プレビュー再生しながら WAV 書き出しまで行えます。
+
+## できること
+
+- 音声プロジェクトの新規作成 / 保存 / 読込
+- タイムライン上でのノート作成、移動、長さ変更
+- note / track / project パラメータの編集
+- Render Preview / Play / Pause / Stop / Rewind / Loop
+- WAV 書き出し
+- Undo / Redo
+
+## 同梱内容
+
+- `TorusEdison-0.1.0.unitypackage`
+- 日本語マニュアル
+- English manual
+- 利用規約
+- リリースノート
+- 検証チェックリスト
+- サンプル `.gats.json`
+
+## 対応環境
+
+- Unity `6000.0` 以上
+- Windows 11 で確認した Unity Editor 環境
+
+## 向いている用途
+
+- ゲーム開発中の仮 SE 作成
+- 短いループや UI 音の試作
+- JSON ベースで管理したい簡易音声ワークフロー
+
+## 現在の制限
+
+- DAW のような本格的な音楽制作ツールではありません
+- 多言語 UI は未実装です
+- 詳細なデバッグログ切替は未実装です
+- editor UX は今後も改善予定です
+
+## ご購入前にご確認ください
+
+- 利用規約を必ず確認してください
+- 本ツールは Unity Editor 上で利用するエディタ拡張です
+- Unity プロジェクトへ導入して使用します
+
+## サポート
+
+- 不具合報告や更新情報は GitHub Release を基準に案内します
+- BOOTH 配布物と GitHub Release の成果物は同一内容を前提にしています

--- a/tools/release/GitHubReleaseBody.ja.md
+++ b/tools/release/GitHubReleaseBody.ja.md
@@ -1,0 +1,46 @@
+# Torus Edison v0.1.0
+
+Unity Editor 上で簡単なゲーム音を作成し、`.gats.json` と WAV で扱えるようにするエディタ拡張ツールです。
+
+## 含まれるもの
+
+- `TorusEdison-0.1.0.unitypackage`
+- 日本語 / 英語マニュアル
+- 利用規約
+- リリースノート
+- 検証チェックリスト
+- サンプル `.gats.json`
+
+## 主な機能
+
+- `.gats.json` ベースの音声プロジェクト保存 / 読込
+- タイムライン上でのノート配置、移動、長さ変更
+- note / track / project inspector 編集
+- Render Preview / Play / Pause / Stop / Rewind / Loop
+- WAV 書き出し
+- Undo / Redo
+
+## 同梱サンプル
+
+- `Basic SE`
+- `Simple Loop`
+
+## 既知の制限
+
+- マウス主体の editor workflow は MVP 段階です
+- UI の多言語対応は未実装です
+- デバッグログの詳細切替は未実装です
+- Unity batch `-runTests -testResults ...` はこの環境では XML を出力しないため、最終確認は手動検証を含みます
+
+## ドキュメント
+
+- 日本語マニュアル: `Manual.ja.md`
+- English manual: `Manual.md`
+- 利用規約: `TermsOfUse.md`
+- リリースノート: `ReleaseNotes.md`
+- 検証チェックリスト: `ValidationChecklist.md`
+
+## 備考
+
+- GitHub リポジトリ名は `SoundCreater` ですが、公開名は `Torus Edison` です
+- BOOTH 配布物も同一成果物を前提にしています

--- a/tools/release/README.md
+++ b/tools/release/README.md
@@ -28,6 +28,13 @@ The release zip is expected to contain:
 - `Samples/SimpleLoop.gats.json`
 - `TorusEdison-<version>.unitypackage`
 
+## Publishing Text
+
+Use these files as the source text when publishing:
+
+- `GitHubReleaseBody.ja.md`
+- `BOOTHDescription.ja.md`
+
 ## Build Command
 
 Run from the repository root:
@@ -54,3 +61,5 @@ Before attaching the zip to GitHub Release:
 5. Confirm the unitypackage and zip were both created
 6. Open the zip and verify the expected files are present
 7. Keep the GitHub Release artifact and BOOTH artifact identical
+8. Use `GitHubReleaseBody.ja.md` for the GitHub Release body
+9. Use `BOOTHDescription.ja.md` for the BOOTH listing text


### PR DESCRIPTION
## Summary
- add GitHub Release body source text for Torus Edison v0.1.0
- add BOOTH listing source text for the same artifact
- update the release workflow README to point at the publication text files
- expose the generic GitHub Release page from README

## Validation
- reviewed the publication text files in UTF-8
- ran `git diff --check` on the touched files

Closes #12