### PR TITLE
Add diagnostic logging mode and log level controls

### DIFF
--- a/Packages/com.sunmax.trusedison/Editor/Audio/GameAudioPreviewPlaybackService.cs
+++ b/Packages/com.sunmax.trusedison/Editor/Audio/GameAudioPreviewPlaybackService.cs
@@ -1,5 +1,6 @@
 using System;
 using TorusEdison.Editor.Domain;
+using TorusEdison.Editor.Utilities;
 using UnityEditor;
 using UnityEngine;
 
@@ -53,6 +54,7 @@ namespace TorusEdison.Editor.Audio
         public GameAudioPreviewState Prepare(GameAudioProject project)
         {
             EnsurePreview(project);
+            GameAudioDiagnosticLogger.Info("Preview", $"Prepared preview for {project?.Name ?? "(null)"}. Status={_statusText}");
             return State;
         }
 
@@ -84,11 +86,13 @@ namespace TorusEdison.Editor.Audio
                 _statusText = _loopPlayback
                     ? "Loop preview playing."
                     : "Preview playing.";
+                GameAudioDiagnosticLogger.Info("Preview", $"Playback started. Loop={_loopPlayback}; ResumeSeconds={resumeSeconds:0.###}");
             }
             catch (Exception exception)
             {
                 StopInternal(true, "Preview start failed.");
                 _errorText = exception.Message;
+                GameAudioDiagnosticLogger.Exception("Preview", exception, "Preview playback start failed");
             }
 
             return State;
@@ -112,6 +116,7 @@ namespace TorusEdison.Editor.Audio
 
             _playbackSeconds = CalculatePlaybackSeconds(Math.Max(0.0d, EditorApplication.timeSinceStartup - _playbackStartedAt));
             StopInternal(false, _loopPlayback ? "Loop preview paused." : "Preview paused.", true);
+            GameAudioDiagnosticLogger.Info("Preview", $"Playback paused at {_playbackSeconds:0.###} seconds.");
             return State;
         }
 
@@ -124,6 +129,7 @@ namespace TorusEdison.Editor.Audio
             }
 
             StopInternal(true, "Preview stopped.");
+            GameAudioDiagnosticLogger.Info("Preview", "Playback stopped.");
             return State;
         }
 
@@ -136,6 +142,7 @@ namespace TorusEdison.Editor.Audio
             }
 
             StopInternal(true, "Preview rewound.");
+            GameAudioDiagnosticLogger.Info("Preview", "Playback rewound.");
             return State;
         }
 
@@ -206,6 +213,7 @@ namespace TorusEdison.Editor.Audio
                         {
                             StopInternal(true, "Preview loop restart failed.");
                             _errorText = exception.Message;
+                            GameAudioDiagnosticLogger.Exception("Preview", exception, "Loop restart failed");
                             return true;
                         }
                     }
@@ -223,6 +231,7 @@ namespace TorusEdison.Editor.Audio
                 _isPlaying = false;
                 _isPaused = false;
                 _statusText = "Preview complete.";
+                GameAudioDiagnosticLogger.Info("Preview", "Playback completed.");
                 return true;
             }
 
@@ -283,6 +292,9 @@ namespace TorusEdison.Editor.Audio
                 : _renderResult.PeakAmplitude <= 0.0001f
                     ? "Preview ready (silent buffer)."
                     : "Preview ready.";
+            GameAudioDiagnosticLogger.Verbose(
+                "Preview",
+                $"Preview buffer ready. Frames={_renderResult.FrameCount}; ProjectFrames={_renderResult.ProjectFrameCount}; Channels={_renderResult.ChannelCount}; Peak={_renderResult.PeakAmplitude:0.000}");
         }
 
         private static double NormalizeLoopSeconds(double elapsedSeconds, double loopDurationSeconds)

--- a/Packages/com.sunmax.trusedison/Editor/Audio/GameAudioWavExportService.cs
+++ b/Packages/com.sunmax.trusedison/Editor/Audio/GameAudioWavExportService.cs
@@ -28,6 +28,7 @@ namespace TorusEdison.Editor.Audio
             GameAudioRenderResult renderResult = _renderer.Render(project);
             byte[] wavBytes = GameAudioWavEncoder.EncodePcm16(renderResult.Samples, renderResult.SampleRate, renderResult.ChannelCount);
             File.WriteAllBytes(filePath, wavBytes);
+            GameAudioDiagnosticLogger.Verbose("Export", $"Encoded {wavBytes.Length} bytes for {projectName}.");
             return filePath;
         }
     }

--- a/Packages/com.sunmax.trusedison/Editor/Config/GameAudioCommonConfig.cs
+++ b/Packages/com.sunmax.trusedison/Editor/Config/GameAudioCommonConfig.cs
@@ -1,5 +1,6 @@
 using TorusEdison.Editor.Domain;
 using TorusEdison.Editor.Localization;
+using TorusEdison.Editor.Utilities;
 
 namespace TorusEdison.Editor.Config
 {
@@ -20,5 +21,9 @@ namespace TorusEdison.Editor.Config
         public int UndoHistoryLimit { get; set; } = 100;
 
         public GameAudioLanguageMode DisplayLanguage { get; set; } = GameAudioLanguageMode.Auto;
+
+        public bool EnableDiagnosticLogging { get; set; } = false;
+
+        public GameAudioDiagnosticLogLevel DiagnosticLogLevel { get; set; } = GameAudioDiagnosticLogLevel.Info;
     }
 }

--- a/Packages/com.sunmax.trusedison/Editor/Localization/GameAudioLocalization.cs
+++ b/Packages/com.sunmax.trusedison/Editor/Localization/GameAudioLocalization.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
 using TorusEdison.Editor.Domain;
+using TorusEdison.Editor.Utilities;
 using UnityEditor;
 using UnityEngine;
 
@@ -24,6 +25,10 @@ namespace TorusEdison.Editor.Localization
             ["language.japanese"] = "Japanese",
             ["language.english"] = "English",
             ["language.chinese"] = "Chinese",
+            ["logLevel.error"] = "Error",
+            ["logLevel.warning"] = "Warning",
+            ["logLevel.info"] = "Info",
+            ["logLevel.verbose"] = "Verbose",
             ["audio.mono"] = "Mono",
             ["audio.stereo"] = "Stereo",
             ["channel.mono"] = "Mono",
@@ -123,6 +128,9 @@ namespace TorusEdison.Editor.Localization
             ["inspector.toolSettings"] = "ツール設定",
             ["inspector.language"] = "表示言語",
             ["inspector.language.help"] = "自動は、取得できる場合は現在の Unity Editor の言語に追従します。上書き設定はサポート時やスクリーンショットの統一に便利です。",
+            ["inspector.debugMode"] = "デバッグモード",
+            ["inspector.logLevel"] = "ログレベル",
+            ["inspector.diagnostics.help"] = "有効にすると、Torus Edison は Unity Console へ診断ログを出力します。エンドユーザ調査時は必要に応じてログレベルを上げてください。",
             ["inspector.selectTrackOrNote"] = "編集を始めるには、タイムラインでトラックヘッダーまたはノートを選択してください。",
             ["inspector.note.singleSummary"] = "{1} 上のノート {0} を編集中です。",
             ["inspector.note.multiSummary"] = "{1} トラックにまたがる {0} 個のノートを編集中です。変更はすべての選択ノートに適用されます。",
@@ -221,6 +229,10 @@ namespace TorusEdison.Editor.Localization
             ["language.japanese"] = "日语",
             ["language.english"] = "英语",
             ["language.chinese"] = "中文",
+            ["logLevel.error"] = "错误",
+            ["logLevel.warning"] = "警告",
+            ["logLevel.info"] = "信息",
+            ["logLevel.verbose"] = "详细",
             ["audio.mono"] = "单声道",
             ["audio.stereo"] = "立体声",
             ["channel.mono"] = "单声道",
@@ -302,6 +314,9 @@ namespace TorusEdison.Editor.Localization
             ["inspector.toolSettings"] = "工具设置",
             ["inspector.language"] = "显示语言",
             ["inspector.language.help"] = "自动模式会在可用时跟随当前 Unity Editor 语言。覆盖模式适合客服支持和统一截图语言。",
+            ["inspector.debugMode"] = "调试模式",
+            ["inspector.logLevel"] = "日志级别",
+            ["inspector.diagnostics.help"] = "启用后，Torus Edison 会向 Unity Console 输出诊断日志。与终端用户一起排查时，可按需提高日志级别。",
             ["inspector.selectTrackOrNote"] = "请先在时间线中选择轨道标题或音符，再开始编辑。",
             ["inspector.note.singleSummary"] = "正在编辑 {1} 上的音符 {0}。",
             ["inspector.note.multiSummary"] = "正在编辑跨 {1} 条轨道的 {0} 个音符。修改会应用到所有已选音符。",
@@ -473,6 +488,19 @@ namespace TorusEdison.Editor.Localization
                 });
         }
 
+        public static string GetDiagnosticLogLevelLabel(GameAudioDisplayLanguage language, GameAudioDiagnosticLogLevel logLevel)
+        {
+            return Get(
+                language,
+                logLevel switch
+                {
+                    GameAudioDiagnosticLogLevel.Error => "logLevel.error",
+                    GameAudioDiagnosticLogLevel.Warning => "logLevel.warning",
+                    GameAudioDiagnosticLogLevel.Verbose => "logLevel.verbose",
+                    _ => "logLevel.info"
+                });
+        }
+
         public static string GetChannelModeLabel(GameAudioDisplayLanguage language, GameAudioChannelMode channelMode)
         {
             return Get(
@@ -511,7 +539,7 @@ namespace TorusEdison.Editor.Localization
             {
                 Type localizationDatabaseType = typeof(EditorWindow).Assembly.GetType("UnityEditor.LocalizationDatabase");
                 PropertyInfo enabledProperty = localizationDatabaseType?.GetProperty("enableEditorLocalization", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
-                bool isLocalizationEnabled = enabledProperty?.GetValue(null) as bool? ?? false;
+                bool isLocalizationEnabled = enabledProperty?.GetValue(null) is bool enabled && enabled;
                 if (!isLocalizationEnabled)
                 {
                     return UnityEngine.Application.systemLanguage;

--- a/Packages/com.sunmax.trusedison/Editor/Persistence/GameAudioCommonConfigSerializer.cs
+++ b/Packages/com.sunmax.trusedison/Editor/Persistence/GameAudioCommonConfigSerializer.cs
@@ -25,8 +25,9 @@ namespace TorusEdison.Editor.Persistence
             {
                 return Deserialize(File.ReadAllText(resolvedPath, Utf8WithoutBom));
             }
-            catch (Exception)
+            catch (Exception exception)
             {
+                GameAudioDiagnosticLogger.Warning("Config", $"Common config fallback was applied for {resolvedPath}. {exception.Message}");
                 return new GameAudioCommonConfig();
             }
         }
@@ -70,7 +71,9 @@ namespace TorusEdison.Editor.Persistence
                     ? "1/16"
                     : config.DefaultGridDivision,
                 undoHistoryLimit = GameAudioValidationUtility.ClampInt(config.UndoHistoryLimit, 1, 1000),
-                displayLanguage = config.DisplayLanguage.ToString()
+                displayLanguage = config.DisplayLanguage.ToString(),
+                enableDiagnosticLogging = config.EnableDiagnosticLogging,
+                diagnosticLogLevel = config.DiagnosticLogLevel.ToString()
             };
 
             return JsonUtility.ToJson(dto, true) + "\n";
@@ -88,8 +91,9 @@ namespace TorusEdison.Editor.Persistence
             {
                 dto = JsonUtility.FromJson<GameAudioCommonConfigDto>(json);
             }
-            catch (Exception)
+            catch (Exception exception)
             {
+                GameAudioDiagnosticLogger.Warning("Config", $"Common config JSON could not be parsed. {exception.Message}");
                 return new GameAudioCommonConfig();
             }
 
@@ -117,7 +121,11 @@ namespace TorusEdison.Editor.Persistence
                 UndoHistoryLimit = GameAudioValidationUtility.ClampInt(dto.undoHistoryLimit <= 0 ? 100 : dto.undoHistoryLimit, 1, 1000),
                 DisplayLanguage = Enum.TryParse(dto.displayLanguage, true, out GameAudioLanguageMode displayLanguage)
                     ? displayLanguage
-                    : GameAudioLanguageMode.Auto
+                    : GameAudioLanguageMode.Auto,
+                EnableDiagnosticLogging = dto.enableDiagnosticLogging,
+                DiagnosticLogLevel = Enum.TryParse(dto.diagnosticLogLevel, true, out GameAudioDiagnosticLogLevel diagnosticLogLevel)
+                    ? diagnosticLogLevel
+                    : GameAudioDiagnosticLogLevel.Info
             };
         }
     }

--- a/Packages/com.sunmax.trusedison/Editor/Persistence/GameAudioPersistenceDtos.cs
+++ b/Packages/com.sunmax.trusedison/Editor/Persistence/GameAudioPersistenceDtos.cs
@@ -108,6 +108,8 @@ namespace TorusEdison.Editor.Persistence
         public string defaultGridDivision;
         public int undoHistoryLimit;
         public string displayLanguage;
+        public bool enableDiagnosticLogging;
+        public string diagnosticLogLevel;
     }
 
     [Serializable]

--- a/Packages/com.sunmax.trusedison/Editor/Persistence/GameAudioProjectConfigSerializer.cs
+++ b/Packages/com.sunmax.trusedison/Editor/Persistence/GameAudioProjectConfigSerializer.cs
@@ -24,8 +24,9 @@ namespace TorusEdison.Editor.Persistence
             {
                 return Deserialize(File.ReadAllText(resolvedPath, Utf8WithoutBom));
             }
-            catch (Exception)
+            catch (Exception exception)
             {
+                GameAudioDiagnosticLogger.Warning("Config", $"Project config fallback was applied for {resolvedPath}. {exception.Message}");
                 return new GameAudioProjectConfig();
             }
         }
@@ -77,8 +78,9 @@ namespace TorusEdison.Editor.Persistence
             {
                 dto = JsonUtility.FromJson<GameAudioProjectConfigDto>(json);
             }
-            catch (Exception)
+            catch (Exception exception)
             {
+                GameAudioDiagnosticLogger.Warning("Config", $"Project config JSON could not be parsed. {exception.Message}");
                 return new GameAudioProjectConfig();
             }
 

--- a/Packages/com.sunmax.trusedison/Editor/Persistence/GameAudioProjectSerializer.cs
+++ b/Packages/com.sunmax.trusedison/Editor/Persistence/GameAudioProjectSerializer.cs
@@ -42,6 +42,7 @@ namespace TorusEdison.Editor.Persistence
             }
 
             File.WriteAllText(resolvedPath, Serialize(project), Utf8WithoutBom);
+            GameAudioDiagnosticLogger.Verbose("ProjectSerializer", $"Serialized project file to {resolvedPath}.");
         }
 
         public GameAudioProjectLoadResult LoadFromFile(string path)
@@ -59,7 +60,9 @@ namespace TorusEdison.Editor.Persistence
             }
 
             string json = File.ReadAllText(path, Utf8WithoutBom);
-            return Deserialize(json);
+            GameAudioProjectLoadResult result = Deserialize(json);
+            GameAudioDiagnosticLogger.Verbose("ProjectSerializer", $"Loaded project file {path} with {result.Warnings.Count} warning(s).");
+            return result;
         }
 
         public GameAudioProjectLoadResult Deserialize(string json)

--- a/Packages/com.sunmax.trusedison/Editor/Utilities/GameAudioDiagnosticLogLevel.cs
+++ b/Packages/com.sunmax.trusedison/Editor/Utilities/GameAudioDiagnosticLogLevel.cs
@@ -1,0 +1,10 @@
+namespace TorusEdison.Editor.Utilities
+{
+    public enum GameAudioDiagnosticLogLevel
+    {
+        Error = 0,
+        Warning = 1,
+        Info = 2,
+        Verbose = 3
+    }
+}

--- a/Packages/com.sunmax.trusedison/Editor/Utilities/GameAudioDiagnosticLogLevel.cs.meta
+++ b/Packages/com.sunmax.trusedison/Editor/Utilities/GameAudioDiagnosticLogLevel.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c4d319edb9d2450cbf88737ed27c1918

--- a/Packages/com.sunmax.trusedison/Editor/Utilities/GameAudioDiagnosticLogger.cs
+++ b/Packages/com.sunmax.trusedison/Editor/Utilities/GameAudioDiagnosticLogger.cs
@@ -1,0 +1,93 @@
+using System;
+using TorusEdison.Editor.Config;
+using UnityEngine;
+
+namespace TorusEdison.Editor.Utilities
+{
+    internal static class GameAudioDiagnosticLogger
+    {
+        private const string Prefix = "[Torus Edison]";
+
+        private static bool _enabled;
+        private static GameAudioDiagnosticLogLevel _minimumLevel = GameAudioDiagnosticLogLevel.Info;
+
+        public static bool IsEnabled => _enabled;
+
+        public static GameAudioDiagnosticLogLevel MinimumLevel => _minimumLevel;
+
+        public static void Configure(GameAudioCommonConfig config)
+        {
+            Configure(
+                config?.EnableDiagnosticLogging ?? false,
+                config?.DiagnosticLogLevel ?? GameAudioDiagnosticLogLevel.Info);
+        }
+
+        public static void Configure(bool enabled, GameAudioDiagnosticLogLevel minimumLevel)
+        {
+            _enabled = enabled;
+            _minimumLevel = minimumLevel;
+        }
+
+        public static void Error(string area, string message)
+        {
+            Log(GameAudioDiagnosticLogLevel.Error, area, message);
+        }
+
+        public static void Warning(string area, string message)
+        {
+            Log(GameAudioDiagnosticLogLevel.Warning, area, message);
+        }
+
+        public static void Info(string area, string message)
+        {
+            Log(GameAudioDiagnosticLogLevel.Info, area, message);
+        }
+
+        public static void Verbose(string area, string message)
+        {
+            Log(GameAudioDiagnosticLogLevel.Verbose, area, message);
+        }
+
+        public static void Exception(string area, Exception exception, string context = null)
+        {
+            if (exception == null)
+            {
+                return;
+            }
+
+            string message = string.IsNullOrWhiteSpace(context)
+                ? exception.Message
+                : $"{context}: {exception.Message}";
+            Log(GameAudioDiagnosticLogLevel.Error, area, message, exception);
+        }
+
+        private static void Log(GameAudioDiagnosticLogLevel level, string area, string message, Exception exception = null)
+        {
+            if (!_enabled || level > _minimumLevel)
+            {
+                return;
+            }
+
+            string normalizedArea = string.IsNullOrWhiteSpace(area) ? "General" : area;
+            string normalizedMessage = string.IsNullOrWhiteSpace(message) ? "(no message)" : message;
+            string formatted = $"{Prefix}[{normalizedArea}][{level}] {normalizedMessage}";
+            if (exception != null)
+            {
+                formatted = $"{formatted}\n{exception}";
+            }
+
+            switch (level)
+            {
+                case GameAudioDiagnosticLogLevel.Error:
+                    Debug.LogError(formatted);
+                    break;
+                case GameAudioDiagnosticLogLevel.Warning:
+                    Debug.LogWarning(formatted);
+                    break;
+                default:
+                    Debug.Log(formatted);
+                    break;
+            }
+        }
+    }
+}

--- a/Packages/com.sunmax.trusedison/Editor/Utilities/GameAudioDiagnosticLogger.cs.meta
+++ b/Packages/com.sunmax.trusedison/Editor/Utilities/GameAudioDiagnosticLogger.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 67a6a86e2120498cb50d68b68cbfbb3e

--- a/Packages/com.sunmax.trusedison/Editor/Windows/GameAudioToolWindow.cs
+++ b/Packages/com.sunmax.trusedison/Editor/Windows/GameAudioToolWindow.cs
@@ -100,6 +100,7 @@ namespace TorusEdison.Editor.Windows
         {
             _commonConfig = _commonConfigSerializer.LoadOrDefault();
             _projectConfig = _projectConfigSerializer.LoadOrDefault(GameAudioConfigPaths.GetProjectConfigPath(GetProjectRootPath()));
+            GameAudioDiagnosticLogger.Configure(_commonConfig);
             _currentGridDivision = GameAudioTimelineGridUtility.NormalizeDivision(_commonConfig.DefaultGridDivision);
             _displayLanguage = GameAudioLocalization.ResolveLanguage(_commonConfig.DisplayLanguage);
 
@@ -998,6 +999,21 @@ namespace TorusEdison.Editor.Windows
             parent.Add(CreateInspectorHelpBox(
                 T("inspector.language.help", "Auto follows the current Unity Editor language when available. Override is useful for support and screenshot consistency."),
                 HelpBoxMessageType.Info));
+            AddInspectorToggleField(
+                parent,
+                T("inspector.debugMode", "Debug Mode"),
+                _commonConfig?.EnableDiagnosticLogging ?? false,
+                OnDiagnosticLoggingChanged);
+            AddInspectorPopupField(
+                parent,
+                T("inspector.logLevel", "Log Level"),
+                GetSupportedDiagnosticLogLevels(),
+                _commonConfig?.DiagnosticLogLevel ?? GameAudioDiagnosticLogLevel.Info,
+                option => GameAudioLocalization.GetDiagnosticLogLevelLabel(_displayLanguage, option),
+                OnDiagnosticLogLevelChanged);
+            parent.Add(CreateInspectorHelpBox(
+                T("inspector.diagnostics.help", "When enabled, Torus Edison writes diagnostic flow and failure logs to the Unity Console. Increase the level when troubleshooting with end users."),
+                HelpBoxMessageType.Info));
         }
 
         private void AddVoiceInspector(
@@ -1232,6 +1248,11 @@ namespace TorusEdison.Editor.Windows
             yield return FormatSampleRateOption(GameAudioToolInfo.AlternateSampleRate);
         }
 
+        private static IEnumerable<GameAudioDiagnosticLogLevel> GetSupportedDiagnosticLogLevels()
+        {
+            return (GameAudioDiagnosticLogLevel[])Enum.GetValues(typeof(GameAudioDiagnosticLogLevel));
+        }
+
         private static IEnumerable<GameAudioChannelMode> GetSupportedChannelModeOptions()
         {
             return (GameAudioChannelMode[])Enum.GetValues(typeof(GameAudioChannelMode));
@@ -1301,8 +1322,9 @@ namespace TorusEdison.Editor.Windows
             ShowNotification(new GUIContent(TF("notification.requiresFinite", "{0} requires a finite number.", fieldName)));
         }
 
-        private void ShowEditorException(Exception exception)
+        private void ShowEditorException(Exception exception, string area = "Window", string context = null)
         {
+            GameAudioDiagnosticLogger.Exception(area, exception, context);
             EditorUtility.DisplayDialog(GameAudioToolInfo.DisplayName, exception.Message, T("dialog.ok", "OK"));
         }
 
@@ -1323,7 +1345,7 @@ namespace TorusEdison.Editor.Windows
             }
             catch (Exception exception)
             {
-                ShowEditorException(exception);
+                ShowEditorException(exception, "Edit", $"Project change failed: {displayName}");
             }
         }
 
@@ -1351,7 +1373,7 @@ namespace TorusEdison.Editor.Windows
             }
             catch (Exception exception)
             {
-                ShowEditorException(exception);
+                ShowEditorException(exception, "Edit", $"Track change failed: {displayName}");
             }
         }
 
@@ -1380,7 +1402,7 @@ namespace TorusEdison.Editor.Windows
             }
             catch (Exception exception)
             {
-                ShowEditorException(exception);
+                ShowEditorException(exception, "Edit", $"Note change failed: {displayName}");
             }
         }
 
@@ -1441,12 +1463,13 @@ namespace TorusEdison.Editor.Windows
                 _projectSerializer.SaveToFile(resolvedPath, CurrentProject);
                 _projectPath = resolvedPath;
                 _isDirty = false;
+                GameAudioDiagnosticLogger.Info("Project", $"Saved project to {resolvedPath}.");
                 ShowNotification(new GUIContent(T("status.projectSaved", "Project saved.")));
                 RefreshView();
             }
             catch (Exception exception)
             {
-                EditorUtility.DisplayDialog(GameAudioToolInfo.DisplayName, exception.Message, T("dialog.ok", "OK"));
+                ShowEditorException(exception, "Project", $"Saving project failed: {targetPath}");
             }
         }
 
@@ -1517,8 +1540,44 @@ namespace TorusEdison.Editor.Windows
 
             _commonConfig.DisplayLanguage = nextLanguage;
             SaveCommonConfig();
+            GameAudioDiagnosticLogger.Configure(_commonConfig);
             _displayLanguage = GameAudioLocalization.ResolveLanguage(nextLanguage);
+            GameAudioDiagnosticLogger.Info("Settings", $"Display language changed to {nextLanguage}.");
             CreateGUI();
+        }
+
+        private void OnDiagnosticLoggingChanged(bool enabled)
+        {
+            _commonConfig ??= _commonConfigSerializer.LoadOrDefault();
+            if (_commonConfig.EnableDiagnosticLogging == enabled)
+            {
+                return;
+            }
+
+            _commonConfig.EnableDiagnosticLogging = enabled;
+            SaveCommonConfig();
+            GameAudioDiagnosticLogger.Configure(_commonConfig);
+            if (enabled)
+            {
+                GameAudioDiagnosticLogger.Info("Settings", $"Diagnostic logging enabled at {_commonConfig.DiagnosticLogLevel}.");
+            }
+
+            RefreshView();
+        }
+
+        private void OnDiagnosticLogLevelChanged(GameAudioDiagnosticLogLevel nextLogLevel)
+        {
+            _commonConfig ??= _commonConfigSerializer.LoadOrDefault();
+            if (_commonConfig.DiagnosticLogLevel == nextLogLevel)
+            {
+                return;
+            }
+
+            _commonConfig.DiagnosticLogLevel = nextLogLevel;
+            SaveCommonConfig();
+            GameAudioDiagnosticLogger.Configure(_commonConfig);
+            GameAudioDiagnosticLogger.Info("Settings", $"Diagnostic log level changed to {nextLogLevel}.");
+            RefreshView();
         }
 
         private void OnCommonExportDirectoryChanged(ChangeEvent<string> evt)
@@ -1535,11 +1594,13 @@ namespace TorusEdison.Editor.Windows
             {
                 _commonConfig.DefaultExportDirectory = normalizedValue;
                 SaveCommonConfig();
+                GameAudioDiagnosticLogger.Configure(_commonConfig);
+                GameAudioDiagnosticLogger.Verbose("Settings", $"Common export directory set to {normalizedValue}.");
                 RefreshView();
             }
             catch (Exception exception)
             {
-                ShowEditorException(exception);
+                ShowEditorException(exception, "Settings", "Saving common export directory failed");
             }
         }
 
@@ -1556,11 +1617,12 @@ namespace TorusEdison.Editor.Windows
             {
                 _projectConfig.ExportDirectory = nextValue;
                 SaveProjectConfig();
+                GameAudioDiagnosticLogger.Verbose("Settings", $"Project export directory set to {nextValue}.");
                 RefreshView();
             }
             catch (Exception exception)
             {
-                ShowEditorException(exception);
+                ShowEditorException(exception, "Settings", "Saving project export directory failed");
             }
         }
 
@@ -1576,11 +1638,12 @@ namespace TorusEdison.Editor.Windows
             {
                 _projectConfig.AutoRefreshAfterExport = evt.newValue;
                 SaveProjectConfig();
+                GameAudioDiagnosticLogger.Verbose("Settings", $"Auto refresh after export set to {evt.newValue}.");
                 RefreshView();
             }
             catch (Exception exception)
             {
-                ShowEditorException(exception);
+                ShowEditorException(exception, "Settings", "Saving auto refresh setting failed");
             }
         }
 
@@ -1605,6 +1668,7 @@ namespace TorusEdison.Editor.Windows
                     AssetDatabase.Refresh();
                 }
 
+                GameAudioDiagnosticLogger.Info("Export", $"Exported WAV to {exportPath}. AutoRefresh={shouldRefresh}.");
                 ShowNotification(new GUIContent(shouldRefresh
                     ? T("status.wavExportedAndRefreshed", "WAV exported and assets refreshed.")
                     : T("status.wavExported", "WAV exported.")));
@@ -1612,7 +1676,7 @@ namespace TorusEdison.Editor.Windows
             }
             catch (Exception exception)
             {
-                ShowEditorException(exception);
+                ShowEditorException(exception, "Export", "WAV export failed");
             }
         }
 
@@ -1622,11 +1686,12 @@ namespace TorusEdison.Editor.Windows
             {
                 string exportDirectory = GetResolvedExportDirectory();
                 Directory.CreateDirectory(exportDirectory);
+                GameAudioDiagnosticLogger.Verbose("Export", $"Opening export folder {exportDirectory}.");
                 EditorUtility.RevealInFinder(exportDirectory);
             }
             catch (Exception exception)
             {
-                ShowEditorException(exception);
+                ShowEditorException(exception, "Export", "Opening export folder failed");
             }
         }
 
@@ -1640,7 +1705,7 @@ namespace TorusEdison.Editor.Windows
             }
             catch (Exception exception)
             {
-                EditorUtility.DisplayDialog(GameAudioToolInfo.DisplayName, exception.Message, T("dialog.ok", "OK"));
+                ShowEditorException(exception, "Preview", "Preview render failed");
             }
         }
 
@@ -1654,25 +1719,28 @@ namespace TorusEdison.Editor.Windows
             }
             catch (Exception exception)
             {
-                EditorUtility.DisplayDialog(GameAudioToolInfo.DisplayName, exception.Message, T("dialog.ok", "OK"));
+                ShowEditorException(exception, "Preview", "Preview playback failed");
             }
         }
 
         private void StopPreview()
         {
             _previewPlaybackService.Stop();
+            GameAudioDiagnosticLogger.Verbose("Preview", "Preview stop requested.");
             RefreshView();
         }
 
         private void PausePreview()
         {
             _previewPlaybackService.Pause();
+            GameAudioDiagnosticLogger.Verbose("Preview", "Preview pause requested.");
             RefreshView();
         }
 
         private void RewindPreview()
         {
             _previewPlaybackService.Rewind();
+            GameAudioDiagnosticLogger.Verbose("Preview", "Preview rewind requested.");
             RefreshView();
         }
 
@@ -1692,7 +1760,7 @@ namespace TorusEdison.Editor.Windows
             }
             catch (Exception exception)
             {
-                ShowEditorException(exception);
+                ShowEditorException(exception, "Preview", "Loop playback toggle failed");
             }
         }
 
@@ -1800,7 +1868,7 @@ namespace TorusEdison.Editor.Windows
             }
             catch (Exception exception)
             {
-                EditorUtility.DisplayDialog(GameAudioToolInfo.DisplayName, exception.Message, T("dialog.ok", "OK"));
+                ShowEditorException(exception, "Edit", "Duplicating notes failed");
             }
         }
 
@@ -1821,7 +1889,7 @@ namespace TorusEdison.Editor.Windows
             }
             catch (Exception exception)
             {
-                EditorUtility.DisplayDialog(GameAudioToolInfo.DisplayName, exception.Message, T("dialog.ok", "OK"));
+                ShowEditorException(exception, "Edit", "Deleting notes failed");
             }
         }
 
@@ -1830,11 +1898,12 @@ namespace TorusEdison.Editor.Windows
             try
             {
                 EnsureSampleProjects();
+                GameAudioDiagnosticLogger.Info("Samples", $"Sample projects ensured at {GetUserProjectFolderPath()}.");
                 ShowNotification(new GUIContent(T("status.samplesCreated", "Sample projects created.")));
             }
             catch (Exception exception)
             {
-                EditorUtility.DisplayDialog(GameAudioToolInfo.DisplayName, exception.Message, T("dialog.ok", "OK"));
+                ShowEditorException(exception, "Samples", "Creating sample projects failed");
             }
         }
 
@@ -1853,11 +1922,12 @@ namespace TorusEdison.Editor.Windows
             try
             {
                 EnsureSampleProjects();
+                GameAudioDiagnosticLogger.Verbose("Samples", $"Opening sample folder {GetUserProjectFolderPath()}.");
                 EditorUtility.RevealInFinder(GetUserProjectFolderPath());
             }
             catch (Exception exception)
             {
-                EditorUtility.DisplayDialog(GameAudioToolInfo.DisplayName, exception.Message, T("dialog.ok", "OK"));
+                ShowEditorException(exception, "Samples", "Opening sample folder failed");
             }
         }
 
@@ -1871,11 +1941,12 @@ namespace TorusEdison.Editor.Windows
             try
             {
                 EnsureSampleProjects();
+                GameAudioDiagnosticLogger.Verbose("Samples", $"Loading sample project {fileName}.");
                 LoadProjectFromPath(Path.Combine(GetUserProjectFolderPath(), fileName));
             }
             catch (Exception exception)
             {
-                EditorUtility.DisplayDialog(GameAudioToolInfo.DisplayName, exception.Message, T("dialog.ok", "OK"));
+                ShowEditorException(exception, "Samples", $"Loading sample project failed: {fileName}");
             }
         }
 
@@ -1885,12 +1956,18 @@ namespace TorusEdison.Editor.Windows
             {
                 GameAudioProjectLoadResult loadResult = _projectSerializer.LoadFromFile(path);
                 BindProject(loadResult.Project, false, path, loadResult.Warnings);
+                if (loadResult.Warnings.Count > 0)
+                {
+                    GameAudioDiagnosticLogger.Warning("Project", $"Loaded project with {loadResult.Warnings.Count} warning(s): {path}");
+                }
+
+                GameAudioDiagnosticLogger.Info("Project", $"Loaded project from {path}.");
                 ShowNotification(new GUIContent(T("status.projectLoaded", "Project loaded.")));
                 RefreshView();
             }
             catch (Exception exception)
             {
-                EditorUtility.DisplayDialog(GameAudioToolInfo.DisplayName, exception.Message, T("dialog.ok", "OK"));
+                ShowEditorException(exception, "Project", $"Loading project failed: {path}");
             }
         }
 
@@ -1936,6 +2013,8 @@ namespace TorusEdison.Editor.Windows
             {
                 ShowNotification(new GUIContent(command.DisplayName));
             }
+
+            GameAudioDiagnosticLogger.Verbose("Edit", $"Executed command: {command.DisplayName}");
         }
 
         private void DrawTimelineGui()
@@ -2379,7 +2458,7 @@ namespace TorusEdison.Editor.Windows
             }
             catch (Exception exception)
             {
-                EditorUtility.DisplayDialog(GameAudioToolInfo.DisplayName, exception.Message, T("dialog.ok", "OK"));
+                ShowEditorException(exception, "Edit", "Timeline interaction commit failed");
                 CancelTimelineInteraction();
                 RefreshView();
             }

--- a/Packages/com.sunmax.trusedison/Tests/Editor/GameAudioConfigSerializerTests.cs
+++ b/Packages/com.sunmax.trusedison/Tests/Editor/GameAudioConfigSerializerTests.cs
@@ -25,7 +25,9 @@ namespace TorusEdison.Editor.Tests
                 RememberLastProject = false,
                 DefaultGridDivision = "1/8",
                 UndoHistoryLimit = 240,
-                DisplayLanguage = GameAudioLanguageMode.Chinese
+                DisplayLanguage = GameAudioLanguageMode.Chinese,
+                EnableDiagnosticLogging = true,
+                DiagnosticLogLevel = GameAudioDiagnosticLogLevel.Verbose
             };
 
             string json = serializer.Serialize(config);
@@ -39,6 +41,8 @@ namespace TorusEdison.Editor.Tests
             Assert.That(result.DefaultGridDivision, Is.EqualTo("1/8"));
             Assert.That(result.UndoHistoryLimit, Is.EqualTo(240));
             Assert.That(result.DisplayLanguage, Is.EqualTo(GameAudioLanguageMode.Chinese));
+            Assert.That(result.EnableDiagnosticLogging, Is.True);
+            Assert.That(result.DiagnosticLogLevel, Is.EqualTo(GameAudioDiagnosticLogLevel.Verbose));
         }
 
         [Test]
@@ -130,6 +134,8 @@ namespace TorusEdison.Editor.Tests
                 Assert.That(result.DefaultChannelMode, Is.EqualTo(GameAudioChannelMode.Stereo));
                 Assert.That(result.UndoHistoryLimit, Is.EqualTo(100));
                 Assert.That(result.DisplayLanguage, Is.EqualTo(GameAudioLanguageMode.Auto));
+                Assert.That(result.EnableDiagnosticLogging, Is.False);
+                Assert.That(result.DiagnosticLogLevel, Is.EqualTo(GameAudioDiagnosticLogLevel.Info));
             }
             finally
             {

--- a/Packages/com.sunmax.trusedison/Tests/Editor/GameAudioDiagnosticLoggerTests.cs
+++ b/Packages/com.sunmax.trusedison/Tests/Editor/GameAudioDiagnosticLoggerTests.cs
@@ -1,0 +1,45 @@
+using NUnit.Framework;
+using TorusEdison.Editor.Utilities;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace TorusEdison.Editor.Tests
+{
+    public sealed class GameAudioDiagnosticLoggerTests
+    {
+        [TearDown]
+        public void TearDown()
+        {
+            GameAudioDiagnosticLogger.Configure(false, GameAudioDiagnosticLogLevel.Info);
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        [Test]
+        public void DisabledLogger_SuppressesInfoLogs()
+        {
+            GameAudioDiagnosticLogger.Configure(false, GameAudioDiagnosticLogLevel.Verbose);
+            GameAudioDiagnosticLogger.Info("Tests", "info suppressed");
+        }
+
+        [Test]
+        public void WarningLevel_LogsWarningsButSuppressesInfo()
+        {
+            GameAudioDiagnosticLogger.Configure(true, GameAudioDiagnosticLogLevel.Warning);
+
+            LogAssert.Expect(LogType.Warning, "[Torus Edison][Tests][Warning] warning visible");
+
+            GameAudioDiagnosticLogger.Info("Tests", "info suppressed");
+            GameAudioDiagnosticLogger.Warning("Tests", "warning visible");
+        }
+
+        [Test]
+        public void VerboseLevel_LogsVerboseMessages()
+        {
+            GameAudioDiagnosticLogger.Configure(true, GameAudioDiagnosticLogLevel.Verbose);
+
+            LogAssert.Expect(LogType.Log, "[Torus Edison][Tests][Verbose] verbose visible");
+
+            GameAudioDiagnosticLogger.Verbose("Tests", "verbose visible");
+        }
+    }
+}

--- a/Packages/com.sunmax.trusedison/Tests/Editor/GameAudioDiagnosticLoggerTests.cs.meta
+++ b/Packages/com.sunmax.trusedison/Tests/Editor/GameAudioDiagnosticLoggerTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5614596372d544f19fbdd3d99f4f6c62


### PR DESCRIPTION
## Summary
- add a shared diagnostic logger with Debug Mode and selectable Error/Warning/Info/Verbose levels
- persist diagnostic logging settings in common config and expose them in the Settings page
- log key save/load/export/preview/edit flows and add targeted logger tests

## Validation
- Unity 6000.4.0f1 batch compile on a temp project copy
- Unity 6000.4.0f1 EditMode targeted test run: `TorusEdison.Editor.Tests.GameAudioConfigSerializerTests`
- Unity 6000.4.0f1 EditMode targeted test run: `TorusEdison.Editor.Tests.GameAudioDiagnosticLoggerTests`

Closes #23