### PR TITLE
[Hotfix-01] Fix inspector slider drag regression

### DIFF
--- a/Packages/com.sunmax.trusedison/Editor/Windows/GameAudioToolWindow.cs
+++ b/Packages/com.sunmax.trusedison/Editor/Windows/GameAudioToolWindow.cs
@@ -781,12 +781,28 @@ namespace TorusEdison.Editor.Windows
             slider.style.flexGrow = 1.0f;
             slider.style.marginRight = 8.0f;
 
+            float committedValue = slider.value;
+            float pendingValue = slider.value;
             var valueLabel = CreateInspectorValueLabel(FormatInspectorValue(slider.value, formatValue));
             slider.RegisterValueChangedCallback(evt =>
             {
+                pendingValue = evt.newValue;
                 valueLabel.text = FormatInspectorValue(evt.newValue, formatValue);
-                onChanged?.Invoke(evt.newValue);
             });
+
+            void CommitPendingValue()
+            {
+                if (Mathf.Approximately(pendingValue, committedValue))
+                {
+                    return;
+                }
+
+                committedValue = pendingValue;
+                onChanged?.Invoke(pendingValue);
+            }
+
+            slider.RegisterCallback<PointerCaptureOutEvent>(_ => CommitPendingValue());
+            slider.RegisterCallback<FocusOutEvent>(_ => CommitPendingValue());
 
             fieldContainer.Add(slider);
             fieldContainer.Add(valueLabel);
@@ -815,12 +831,28 @@ namespace TorusEdison.Editor.Windows
             slider.style.flexGrow = 1.0f;
             slider.style.marginRight = 8.0f;
 
+            int committedValue = slider.value;
+            int pendingValue = slider.value;
             var valueLabel = CreateInspectorValueLabel(FormatInspectorValue(slider.value, formatValue));
             slider.RegisterValueChangedCallback(evt =>
             {
+                pendingValue = evt.newValue;
                 valueLabel.text = FormatInspectorValue(evt.newValue, formatValue);
-                onChanged?.Invoke(evt.newValue);
             });
+
+            void CommitPendingValue()
+            {
+                if (pendingValue == committedValue)
+                {
+                    return;
+                }
+
+                committedValue = pendingValue;
+                onChanged?.Invoke(pendingValue);
+            }
+
+            slider.RegisterCallback<PointerCaptureOutEvent>(_ => CommitPendingValue());
+            slider.RegisterCallback<FocusOutEvent>(_ => CommitPendingValue());
 
             fieldContainer.Add(slider);
             fieldContainer.Add(valueLabel);


### PR DESCRIPTION
## Summary
- stop committing slider-backed inspector edits on every drag step
- keep slider labels responsive while deferring the actual command execution until drag release or focus-out
- avoid inspector rebuilds during pointer capture so slider dragging stays usable and undo history is less noisy

## Validation
- `git diff --check`
- Unity 6000.4.0f1 batch compile on a temp project copy

Closes #42