### PR TITLE
Add 8-bit AudioClip conversion export

### DIFF
--- a/Packages/com.sunmax.trusedison/CHANGELOG.md
+++ b/Packages/com.sunmax.trusedison/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- added imported `AudioClip` to 8-bit PCM WAV conversion in the Export page
+- added 8-bit WAV encoder coverage and audio-clip conversion tests
+
 ## 0.1.1
 
 - added UI localization with auto-follow and manual override for Japanese, English, and Chinese

--- a/Packages/com.sunmax.trusedison/Documentation~/Manual.ja.md
+++ b/Packages/com.sunmax.trusedison/Documentation~/Manual.ja.md
@@ -75,11 +75,12 @@
 
 ### Export
 
-この画面では WAV 書き出しを扱います。
+この画面では WAV 書き出しと、Unity に取り込んだ `AudioClip` の 8-bit 変換を扱います。
 
 利用できる操作:
 
 - `Export WAV`
+- Unity に取り込んだ `AudioClip` の 8-bit WAV 変換
 - `Open Export Folder`
 - 共通既定フォルダ設定
 - プロジェクト上書きフォルダ設定
@@ -146,6 +147,18 @@
 - ファイル名禁止文字の補正
 - 出力先フォルダ自動作成
 - `Assets/` 配下書き出し時の `AssetDatabase.Refresh()`
+
+## 8-bit WAV 変換
+
+Export 画面には、Unity に取り込んだ `AudioClip` アセットを 8-bit PCM `.wav` に変換する機能もあります。
+
+- 変換元 `AudioClip` を選択
+- 出力名を指定
+- 変換後サンプルレートを指定
+- `Preserve Source` / `Mono` / `Stereo` を選択
+- 8-bit PCM `.wav` として書き出し
+
+この機能は、すでに Unity へ取り込んだ音声を変換するためのものです。YouTube など外部サービスから音源を取得する機能は含みません。
 
 ## 設定ファイル
 

--- a/Packages/com.sunmax.trusedison/Documentation~/Manual.md
+++ b/Packages/com.sunmax.trusedison/Documentation~/Manual.md
@@ -74,11 +74,12 @@ Current shortcuts:
 
 ### Export
 
-Use this page for WAV export.
+Use this page for WAV export and imported `AudioClip` conversion.
 
 Available controls:
 
 - `Export WAV`
+- imported `AudioClip` to 8-bit WAV conversion
 - `Open Export Folder`
 - common default folder
 - project override folder
@@ -136,6 +137,18 @@ Current WAV export behavior:
 - sanitizes file names
 - creates export folders if needed
 - refreshes `AssetDatabase` when exporting under `Assets/`
+
+## 8-bit WAV Conversion
+
+The Export page also includes a conversion flow for imported `AudioClip` assets.
+
+- select a source `AudioClip` that already exists in the Unity project
+- choose the output name
+- choose the target sample rate
+- choose `Preserve Source`, `Mono`, or `Stereo`
+- export as 8-bit PCM `.wav`
+
+This feature converts audio that you already brought into Unity. It does not download or extract audio from YouTube or other external services.
 
 ## Configuration Files
 

--- a/Packages/com.sunmax.trusedison/Editor/Audio/GameAudioAudioClipConversionService.cs
+++ b/Packages/com.sunmax.trusedison/Editor/Audio/GameAudioAudioClipConversionService.cs
@@ -1,0 +1,204 @@
+using System;
+using System.IO;
+using TorusEdison.Editor.Utilities;
+using UnityEngine;
+
+namespace TorusEdison.Editor.Audio
+{
+    internal sealed class GameAudioAudioClipConversionService
+    {
+        public string ExportAsPcm8(
+            AudioClip sourceClip,
+            string exportDirectory,
+            string outputName,
+            int targetSampleRate,
+            GameAudioConversionChannelMode channelMode)
+        {
+            if (sourceClip == null)
+            {
+                throw new ArgumentNullException(nameof(sourceClip));
+            }
+
+            if (string.IsNullOrWhiteSpace(exportDirectory))
+            {
+                throw new ArgumentException("Export directory is required.", nameof(exportDirectory));
+            }
+
+            int resolvedSampleRate = targetSampleRate > 0 ? targetSampleRate : sourceClip.frequency;
+            if (resolvedSampleRate <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(targetSampleRate));
+            }
+
+            int sourceFrameCount = sourceClip.samples;
+            int sourceChannelCount = sourceClip.channels;
+            if (sourceFrameCount <= 0 || sourceChannelCount <= 0)
+            {
+                throw new InvalidOperationException("Source clip is empty.");
+            }
+
+            var sourceSamples = new float[sourceFrameCount * sourceChannelCount];
+            if (!sourceClip.GetData(sourceSamples, 0))
+            {
+                throw new InvalidOperationException("Source clip samples could not be read.");
+            }
+
+            int outputChannelCount;
+            float[] convertedSamples = ConvertSamples(
+                sourceSamples,
+                sourceFrameCount,
+                sourceChannelCount,
+                sourceClip.frequency,
+                resolvedSampleRate,
+                channelMode,
+                out outputChannelCount);
+
+            string filePath = GameAudioExportUtility.BuildWaveFilePath(exportDirectory, outputName);
+            string directoryPath = Path.GetDirectoryName(filePath);
+            if (string.IsNullOrWhiteSpace(directoryPath))
+            {
+                throw new InvalidOperationException("Export directory could not be resolved.");
+            }
+
+            Directory.CreateDirectory(directoryPath);
+            byte[] wavBytes = GameAudioWavEncoder.EncodePcm8(convertedSamples, resolvedSampleRate, outputChannelCount);
+            File.WriteAllBytes(filePath, wavBytes);
+            GameAudioDiagnosticLogger.Verbose("Conversion", $"Encoded 8-bit WAV {filePath} ({resolvedSampleRate} Hz / {outputChannelCount} ch).");
+            return filePath;
+        }
+
+        internal static float[] ConvertSamples(
+            float[] sourceSamples,
+            int sourceFrameCount,
+            int sourceChannelCount,
+            int sourceSampleRate,
+            int targetSampleRate,
+            GameAudioConversionChannelMode channelMode,
+            out int outputChannelCount)
+        {
+            if (sourceSamples == null)
+            {
+                throw new ArgumentNullException(nameof(sourceSamples));
+            }
+
+            if (sourceFrameCount <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(sourceFrameCount));
+            }
+
+            if (sourceChannelCount <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(sourceChannelCount));
+            }
+
+            if (sourceSampleRate <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(sourceSampleRate));
+            }
+
+            if (targetSampleRate <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(targetSampleRate));
+            }
+
+            if (sourceSamples.Length < sourceFrameCount * sourceChannelCount)
+            {
+                throw new ArgumentException("Source sample buffer is shorter than the declared frame range.", nameof(sourceSamples));
+            }
+
+            outputChannelCount = ResolveOutputChannelCount(sourceChannelCount, channelMode);
+            int outputFrameCount = Math.Max(1, (int)Math.Round(sourceFrameCount * (double)targetSampleRate / sourceSampleRate));
+            var outputSamples = new float[outputFrameCount * outputChannelCount];
+
+            for (int outputFrame = 0; outputFrame < outputFrameCount; outputFrame++)
+            {
+                double sourcePosition = outputFrame * (double)sourceSampleRate / targetSampleRate;
+                int sourceFrameA = Math.Clamp((int)Math.Floor(sourcePosition), 0, sourceFrameCount - 1);
+                int sourceFrameB = Math.Min(sourceFrameA + 1, sourceFrameCount - 1);
+                float blend = (float)(sourcePosition - sourceFrameA);
+
+                for (int channelIndex = 0; channelIndex < outputChannelCount; channelIndex++)
+                {
+                    float sampleA = GetConvertedSample(sourceSamples, sourceFrameA, sourceChannelCount, channelMode, channelIndex);
+                    float sampleB = GetConvertedSample(sourceSamples, sourceFrameB, sourceChannelCount, channelMode, channelIndex);
+                    outputSamples[(outputFrame * outputChannelCount) + channelIndex] = Mathf.Lerp(sampleA, sampleB, blend);
+                }
+            }
+
+            return outputSamples;
+        }
+
+        private static int ResolveOutputChannelCount(int sourceChannelCount, GameAudioConversionChannelMode channelMode)
+        {
+            return channelMode switch
+            {
+                GameAudioConversionChannelMode.Mono => 1,
+                GameAudioConversionChannelMode.Stereo => 2,
+                _ => sourceChannelCount
+            };
+        }
+
+        private static float GetConvertedSample(
+            float[] sourceSamples,
+            int sourceFrame,
+            int sourceChannelCount,
+            GameAudioConversionChannelMode channelMode,
+            int outputChannelIndex)
+        {
+            int frameOffset = sourceFrame * sourceChannelCount;
+            switch (channelMode)
+            {
+                case GameAudioConversionChannelMode.Mono:
+                    return AverageChannels(sourceSamples, frameOffset, sourceChannelCount);
+
+                case GameAudioConversionChannelMode.Stereo:
+                    if (sourceChannelCount == 1)
+                    {
+                        return sourceSamples[frameOffset];
+                    }
+
+                    if (sourceChannelCount == 2)
+                    {
+                        return sourceSamples[frameOffset + Math.Clamp(outputChannelIndex, 0, 1)];
+                    }
+
+                    return outputChannelIndex == 0
+                        ? AverageAlternatingChannels(sourceSamples, frameOffset, sourceChannelCount, 0)
+                        : AverageAlternatingChannels(sourceSamples, frameOffset, sourceChannelCount, 1);
+
+                default:
+                    int sourceChannelIndex = Math.Clamp(outputChannelIndex, 0, sourceChannelCount - 1);
+                    return sourceSamples[frameOffset + sourceChannelIndex];
+            }
+        }
+
+        private static float AverageChannels(float[] sourceSamples, int frameOffset, int sourceChannelCount)
+        {
+            float total = 0.0f;
+            for (int channelIndex = 0; channelIndex < sourceChannelCount; channelIndex++)
+            {
+                total += sourceSamples[frameOffset + channelIndex];
+            }
+
+            return total / sourceChannelCount;
+        }
+
+        private static float AverageAlternatingChannels(float[] sourceSamples, int frameOffset, int sourceChannelCount, int startIndex)
+        {
+            float total = 0.0f;
+            int count = 0;
+            for (int channelIndex = startIndex; channelIndex < sourceChannelCount; channelIndex += 2)
+            {
+                total += sourceSamples[frameOffset + channelIndex];
+                count++;
+            }
+
+            if (count == 0)
+            {
+                return AverageChannels(sourceSamples, frameOffset, sourceChannelCount);
+            }
+
+            return total / count;
+        }
+    }
+}

--- a/Packages/com.sunmax.trusedison/Editor/Audio/GameAudioAudioClipConversionService.cs.meta
+++ b/Packages/com.sunmax.trusedison/Editor/Audio/GameAudioAudioClipConversionService.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: be7275aeddc346d98b12d72bea41616f

--- a/Packages/com.sunmax.trusedison/Editor/Audio/GameAudioConversionChannelMode.cs
+++ b/Packages/com.sunmax.trusedison/Editor/Audio/GameAudioConversionChannelMode.cs
@@ -1,0 +1,9 @@
+namespace TorusEdison.Editor.Audio
+{
+    internal enum GameAudioConversionChannelMode
+    {
+        Preserve = 0,
+        Mono = 1,
+        Stereo = 2
+    }
+}

--- a/Packages/com.sunmax.trusedison/Editor/Audio/GameAudioConversionChannelMode.cs.meta
+++ b/Packages/com.sunmax.trusedison/Editor/Audio/GameAudioConversionChannelMode.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1c0370cd59a4496c91611b8d4b4966ee

--- a/Packages/com.sunmax.trusedison/Editor/Audio/GameAudioWavEncoder.cs
+++ b/Packages/com.sunmax.trusedison/Editor/Audio/GameAudioWavEncoder.cs
@@ -5,10 +5,28 @@ namespace TorusEdison.Editor.Audio
 {
     internal static class GameAudioWavEncoder
     {
-        private const short BitsPerSample = 16;
-        private const short BytesPerSample = BitsPerSample / 8;
+        private const short Pcm16BitsPerSample = 16;
+        private const short Pcm16BytesPerSample = Pcm16BitsPerSample / 8;
+        private const short Pcm8BitsPerSample = 8;
+        private const short Pcm8BytesPerSample = Pcm8BitsPerSample / 8;
 
         public static byte[] EncodePcm16(float[] samples, int sampleRate, int channelCount)
+        {
+            return Encode(samples, sampleRate, channelCount, Pcm16BitsPerSample, Pcm16BytesPerSample, WritePcm16Sample);
+        }
+
+        public static byte[] EncodePcm8(float[] samples, int sampleRate, int channelCount)
+        {
+            return Encode(samples, sampleRate, channelCount, Pcm8BitsPerSample, Pcm8BytesPerSample, WritePcm8Sample);
+        }
+
+        private static byte[] Encode(
+            float[] samples,
+            int sampleRate,
+            int channelCount,
+            short bitsPerSample,
+            short bytesPerSample,
+            Action<BinaryWriter, float> writeSample)
         {
             if (samples == null)
             {
@@ -25,9 +43,14 @@ namespace TorusEdison.Editor.Audio
                 throw new ArgumentOutOfRangeException(nameof(channelCount));
             }
 
-            int dataLength = samples.Length * BytesPerSample;
-            int byteRate = sampleRate * channelCount * BytesPerSample;
-            short blockAlign = (short)(channelCount * BytesPerSample);
+            if (writeSample == null)
+            {
+                throw new ArgumentNullException(nameof(writeSample));
+            }
+
+            int dataLength = samples.Length * bytesPerSample;
+            int byteRate = sampleRate * channelCount * bytesPerSample;
+            short blockAlign = (short)(channelCount * bytesPerSample);
 
             using (var stream = new MemoryStream(44 + dataLength))
             using (var writer = new BinaryWriter(stream))
@@ -42,20 +65,32 @@ namespace TorusEdison.Editor.Audio
                 writer.Write(sampleRate);
                 writer.Write(byteRate);
                 writer.Write(blockAlign);
-                writer.Write(BitsPerSample);
+                writer.Write(bitsPerSample);
                 writer.Write(new[] { 'd', 'a', 't', 'a' });
                 writer.Write(dataLength);
 
                 for (int index = 0; index < samples.Length; index++)
                 {
-                    float clamped = Math.Clamp(samples[index], -1.0f, 1.0f);
-                    short value = (short)Math.Round(clamped * short.MaxValue);
-                    writer.Write(value);
+                    writeSample(writer, samples[index]);
                 }
 
                 writer.Flush();
                 return stream.ToArray();
             }
+        }
+
+        private static void WritePcm16Sample(BinaryWriter writer, float sample)
+        {
+            float clamped = Math.Clamp(sample, -1.0f, 1.0f);
+            short value = (short)Math.Round(clamped * short.MaxValue);
+            writer.Write(value);
+        }
+
+        private static void WritePcm8Sample(BinaryWriter writer, float sample)
+        {
+            float clamped = Math.Clamp(sample, -1.0f, 1.0f);
+            byte value = (byte)Math.Clamp((int)Math.Round((clamped + 1.0f) * 127.5f), 0, byte.MaxValue);
+            writer.Write(value);
         }
     }
 }

--- a/Packages/com.sunmax.trusedison/Editor/Windows/GameAudioToolWindow.cs
+++ b/Packages/com.sunmax.trusedison/Editor/Windows/GameAudioToolWindow.cs
@@ -13,6 +13,7 @@ using TorusEdison.Editor.Localization;
 using TorusEdison.Editor.Persistence;
 using TorusEdison.Editor.Utilities;
 using UnityEditor;
+using UnityEditor.UIElements;
 using UnityEngine;
 using UnityEngine.UIElements;
 
@@ -35,6 +36,7 @@ namespace TorusEdison.Editor.Windows
         private readonly GameAudioPreviewPlaybackService _previewPlaybackService = new GameAudioPreviewPlaybackService();
         private readonly GameAudioProjectSerializer _projectSerializer = new GameAudioProjectSerializer();
         private readonly GameAudioProjectConfigSerializer _projectConfigSerializer = new GameAudioProjectConfigSerializer();
+        private readonly GameAudioAudioClipConversionService _audioClipConversionService = new GameAudioAudioClipConversionService();
         private readonly GameAudioWavExportService _wavExportService = new GameAudioWavExportService();
         private readonly HashSet<string> _selectedNoteIds = new HashSet<string>(StringComparer.Ordinal);
         private readonly Dictionary<WorkspacePage, Button> _workspaceTabButtons = new Dictionary<WorkspacePage, Button>();
@@ -48,6 +50,7 @@ namespace TorusEdison.Editor.Windows
         private bool _isDirty;
         private List<string> _loadWarnings = new List<string>();
         private string _lastExportedPath = string.Empty;
+        private string _lastConverted8BitPath = string.Empty;
         private IVisualElementScheduledItem _previewTicker;
         private TimelineDragState _timelineDragState;
         private Vector2 _timelineScrollPosition;
@@ -55,6 +58,10 @@ namespace TorusEdison.Editor.Windows
         private string _currentGridDivision = "1/16";
         private WorkspacePage _currentWorkspacePage = WorkspacePage.File;
         private GameAudioDisplayLanguage _displayLanguage = GameAudioDisplayLanguage.English;
+        private AudioClip _conversionSourceClip;
+        private string _conversionOutputName = string.Empty;
+        private int _conversionTargetSampleRate = 11025;
+        private GameAudioConversionChannelMode _conversionChannelMode = GameAudioConversionChannelMode.Mono;
 
         private Label _nameValue;
         private Label _bpmValue;
@@ -73,6 +80,11 @@ namespace TorusEdison.Editor.Windows
         private Label _exportResolvedPathValue;
         private Label _exportFileNameValue;
         private Label _exportLastResultValue;
+        private ObjectField _conversionSourceClipField;
+        private TextField _conversionOutputNameField;
+        private PopupField<int> _conversionSampleRateField;
+        private PopupField<GameAudioConversionChannelMode> _conversionChannelModeField;
+        private Label _conversionLastResultValue;
         private IntegerField _toolbarBpmField;
         private PopupField<string> _toolbarGridField;
         private Toggle _toolbarLoopToggle;
@@ -479,6 +491,60 @@ namespace TorusEdison.Editor.Windows
             _autoRefreshAfterExportToggle = new Toggle();
             _autoRefreshAfterExportToggle.RegisterValueChangedCallback(OnAutoRefreshAfterExportChanged);
             panel.Add(CreateInspectorRow(T("export.autoRefresh", "Auto Refresh Assets"), _autoRefreshAfterExportToggle));
+
+            panel.Add(CreateSectionTitle(T("export.convert8Bit.title", "8-bit WAV Conversion")));
+            panel.Add(CreateInspectorHelpBox(
+                T("export.convert8Bit.help", "Select an imported AudioClip asset and convert it to 8-bit PCM WAV. Bring your own audio into Unity first and only convert audio you are allowed to use. This tool does not acquire audio from YouTube or other external services."),
+                HelpBoxMessageType.Info));
+
+            _conversionSourceClipField = new ObjectField
+            {
+                objectType = typeof(AudioClip),
+                allowSceneObjects = false
+            };
+            _conversionSourceClipField.RegisterValueChangedCallback(OnConversionSourceClipChanged);
+            panel.Add(CreateInspectorRow(T("export.convert8Bit.sourceClip", "Source AudioClip"), _conversionSourceClipField));
+
+            _conversionOutputNameField = new TextField
+            {
+                isDelayed = true
+            };
+            _conversionOutputNameField.RegisterValueChangedCallback(OnConversionOutputNameChanged);
+            panel.Add(CreateInspectorRow(T("export.convert8Bit.outputName", "Output Name"), _conversionOutputNameField));
+
+            List<int> sampleRateOptions = GetSupportedConversionSampleRates().ToList();
+            int selectedSampleRateIndex = Math.Max(0, sampleRateOptions.IndexOf(sampleRateOptions.Contains(_conversionTargetSampleRate)
+                ? _conversionTargetSampleRate
+                : sampleRateOptions[0]));
+            _conversionSampleRateField = new PopupField<int>(
+                sampleRateOptions,
+                selectedSampleRateIndex,
+                FormatSampleRateOption,
+                FormatSampleRateOption);
+            _conversionSampleRateField.RegisterValueChangedCallback(OnConversionSampleRateChanged);
+            panel.Add(CreateInspectorRow(T("export.convert8Bit.sampleRate", "Target Sample Rate"), _conversionSampleRateField));
+
+            List<GameAudioConversionChannelMode> channelModeOptions = GetSupportedConversionChannelModes().ToList();
+            int selectedChannelModeIndex = Math.Max(0, channelModeOptions.IndexOf(channelModeOptions.Contains(_conversionChannelMode)
+                ? _conversionChannelMode
+                : channelModeOptions[0]));
+            _conversionChannelModeField = new PopupField<GameAudioConversionChannelMode>(
+                channelModeOptions,
+                selectedChannelModeIndex,
+                FormatConversionChannelMode,
+                FormatConversionChannelMode);
+            _conversionChannelModeField.RegisterValueChangedCallback(OnConversionChannelModeChanged);
+            panel.Add(CreateInspectorRow(T("export.convert8Bit.channelMode", "Channel Mode"), _conversionChannelModeField));
+
+            var conversionActionRow = new VisualElement();
+            conversionActionRow.style.flexDirection = FlexDirection.Row;
+            conversionActionRow.style.alignItems = Align.Center;
+            conversionActionRow.style.flexWrap = Wrap.Wrap;
+            conversionActionRow.style.marginBottom = 8.0f;
+            conversionActionRow.Add(CreateToolbarButton(T("export.convert8Bit.export", "Convert To 8-bit WAV"), Export8BitWav));
+            panel.Add(conversionActionRow);
+
+            _conversionLastResultValue = AddKeyValue(panel, T("export.convert8Bit.lastExport", "Last 8-bit Export"));
 
             return panel;
         }
@@ -1434,6 +1500,21 @@ namespace TorusEdison.Editor.Windows
             return (GameAudioChannelMode[])Enum.GetValues(typeof(GameAudioChannelMode));
         }
 
+        private static IEnumerable<int> GetSupportedConversionSampleRates()
+        {
+            yield return 8000;
+            yield return 11025;
+            yield return 22050;
+            yield return 32000;
+            yield return 44100;
+            yield return 48000;
+        }
+
+        private static IEnumerable<GameAudioConversionChannelMode> GetSupportedConversionChannelModes()
+        {
+            return (GameAudioConversionChannelMode[])Enum.GetValues(typeof(GameAudioConversionChannelMode));
+        }
+
         private static Label CreateInspectorValueLabel(string text)
         {
             var label = new Label(text ?? string.Empty);
@@ -1511,12 +1592,37 @@ namespace TorusEdison.Editor.Windows
             return string.Format(CultureInfo.InvariantCulture, "{0} Hz", sampleRate);
         }
 
+        private string FormatConversionChannelMode(GameAudioConversionChannelMode channelMode)
+        {
+            return channelMode switch
+            {
+                GameAudioConversionChannelMode.Mono => T("export.convert8Bit.channelMode.mono", "Mono"),
+                GameAudioConversionChannelMode.Stereo => T("export.convert8Bit.channelMode.stereo", "Stereo"),
+                _ => T("export.convert8Bit.channelMode.preserve", "Preserve Source")
+            };
+        }
+
         private static int ParseSampleRateOption(string option)
         {
             string digits = new string((option ?? string.Empty).Where(char.IsDigit).ToArray());
             return int.TryParse(digits, NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsed)
                 ? parsed
                 : GameAudioToolInfo.DefaultSampleRate;
+        }
+
+        private string GetResolvedConversionOutputName()
+        {
+            if (!string.IsNullOrWhiteSpace(_conversionOutputName))
+            {
+                return _conversionOutputName;
+            }
+
+            if (_conversionSourceClip != null && !string.IsNullOrWhiteSpace(_conversionSourceClip.name))
+            {
+                return $"{_conversionSourceClip.name}_8bit";
+            }
+
+            return "Converted8Bit";
         }
 
         private static bool IsFinite(float value)
@@ -1971,6 +2077,35 @@ namespace TorusEdison.Editor.Windows
             }
         }
 
+        private void OnConversionSourceClipChanged(ChangeEvent<UnityEngine.Object> evt)
+        {
+            _conversionSourceClip = evt.newValue as AudioClip;
+            if (_conversionSourceClip != null && string.IsNullOrWhiteSpace(_conversionOutputName))
+            {
+                _conversionOutputName = $"{_conversionSourceClip.name}_8bit";
+            }
+
+            RefreshView();
+        }
+
+        private void OnConversionOutputNameChanged(ChangeEvent<string> evt)
+        {
+            _conversionOutputName = evt.newValue?.Trim() ?? string.Empty;
+            RefreshView();
+        }
+
+        private void OnConversionSampleRateChanged(ChangeEvent<int> evt)
+        {
+            _conversionTargetSampleRate = evt.newValue;
+            RefreshView();
+        }
+
+        private void OnConversionChannelModeChanged(ChangeEvent<GameAudioConversionChannelMode> evt)
+        {
+            _conversionChannelMode = evt.newValue;
+            RefreshView();
+        }
+
         private void ExportWav()
         {
             GameAudioProject project = CurrentProject;
@@ -2001,6 +2136,47 @@ namespace TorusEdison.Editor.Windows
             catch (Exception exception)
             {
                 ShowEditorException(exception, "Export", "WAV export failed");
+            }
+        }
+
+        private void Export8BitWav()
+        {
+            if (_conversionSourceClip == null)
+            {
+                ShowEditorException(new InvalidOperationException(T("export.convert8Bit.selectSourceFirst", "Select a source AudioClip first.")), "Conversion", "8-bit WAV export failed");
+                return;
+            }
+
+            try
+            {
+                string exportDirectory = GetResolvedExportDirectory();
+                string outputName = GetResolvedConversionOutputName();
+                string exportPath = _audioClipConversionService.ExportAsPcm8(
+                    _conversionSourceClip,
+                    exportDirectory,
+                    outputName,
+                    _conversionTargetSampleRate,
+                    _conversionChannelMode);
+                _lastConverted8BitPath = exportPath;
+
+                bool shouldRefresh = (_projectConfig?.AutoRefreshAfterExport ?? true)
+                    && GameAudioExportUtility.ShouldRefreshAssetDatabase(exportPath, GetProjectRootPath());
+                if (shouldRefresh)
+                {
+                    AssetDatabase.Refresh();
+                }
+
+                GameAudioDiagnosticLogger.Info(
+                    "Conversion",
+                    $"Exported 8-bit WAV to {exportPath}. AutoRefresh={shouldRefresh}. Source={_conversionSourceClip.name}; SampleRate={_conversionTargetSampleRate}; ChannelMode={_conversionChannelMode}.");
+                ShowNotification(new GUIContent(shouldRefresh
+                    ? T("status.convert8BitExportedAndRefreshed", "8-bit WAV exported and assets refreshed.")
+                    : T("status.convert8BitExported", "8-bit WAV exported.")));
+                RefreshView();
+            }
+            catch (Exception exception)
+            {
+                ShowEditorException(exception, "Conversion", "8-bit WAV export failed");
             }
         }
 
@@ -3126,6 +3302,13 @@ namespace TorusEdison.Editor.Windows
             _exportResolvedPathValue.text = GetResolvedExportDirectory();
             _exportFileNameValue.text = GameAudioExportUtility.NormalizeWaveFileName(project.Name);
             _exportLastResultValue.text = string.IsNullOrWhiteSpace(_lastExportedPath) ? T("status.notExported", "(not exported)") : _lastExportedPath;
+            _conversionSourceClipField?.SetValueWithoutNotify(_conversionSourceClip);
+            _conversionOutputNameField?.SetValueWithoutNotify(_conversionOutputName);
+            _conversionSampleRateField?.SetValueWithoutNotify(_conversionTargetSampleRate);
+            _conversionChannelModeField?.SetValueWithoutNotify(_conversionChannelMode);
+            _conversionLastResultValue.text = string.IsNullOrWhiteSpace(_lastConverted8BitPath)
+                ? T("status.notExported", "(not exported)")
+                : _lastConverted8BitPath;
 
             if (_undoButton != null)
             {

--- a/Packages/com.sunmax.trusedison/Tests/Editor/GameAudioAudioClipConversionServiceTests.cs
+++ b/Packages/com.sunmax.trusedison/Tests/Editor/GameAudioAudioClipConversionServiceTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.IO;
+using NUnit.Framework;
+using TorusEdison.Editor.Audio;
+using UnityEngine;
+
+namespace TorusEdison.Editor.Tests
+{
+    public sealed class GameAudioAudioClipConversionServiceTests
+    {
+        [Test]
+        public void ConvertSamples_DownmixesStereoToMono()
+        {
+            float[] converted = GameAudioAudioClipConversionService.ConvertSamples(
+                new[]
+                {
+                    1.0f, 1.0f,
+                    -1.0f, -1.0f
+                },
+                2,
+                2,
+                22050,
+                22050,
+                GameAudioConversionChannelMode.Mono,
+                out int outputChannels);
+
+            Assert.That(outputChannels, Is.EqualTo(1));
+            Assert.That(converted, Is.EqualTo(new[] { 1.0f, -1.0f }).Within(0.0001f));
+        }
+
+        [Test]
+        public void ConvertSamples_DuplicatesMonoToStereo()
+        {
+            float[] converted = GameAudioAudioClipConversionService.ConvertSamples(
+                new[]
+                {
+                    0.25f,
+                    -0.75f
+                },
+                2,
+                1,
+                22050,
+                22050,
+                GameAudioConversionChannelMode.Stereo,
+                out int outputChannels);
+
+            Assert.That(outputChannels, Is.EqualTo(2));
+            Assert.That(converted, Is.EqualTo(new[] { 0.25f, 0.25f, -0.75f, -0.75f }).Within(0.0001f));
+        }
+
+        [Test]
+        public void ExportAsPcm8_WritesWaveFileToDisk()
+        {
+            string root = Path.Combine(Path.GetTempPath(), "TorusEdisonTests", Path.GetRandomFileName());
+            AudioClip clip = null;
+
+            try
+            {
+                clip = AudioClip.Create("source-clip", 4, 1, 22050, false);
+                clip.SetData(new[] { -1.0f, 0.0f, 1.0f, 0.5f }, 0);
+
+                var service = new GameAudioAudioClipConversionService();
+                string filePath = service.ExportAsPcm8(
+                    clip,
+                    root,
+                    "Converted:Clip",
+                    22050,
+                    GameAudioConversionChannelMode.Preserve);
+
+                Assert.That(File.Exists(filePath), Is.True);
+                Assert.That(Path.GetFileName(filePath), Is.EqualTo("Converted_Clip.wav"));
+
+                byte[] bytes = File.ReadAllBytes(filePath);
+                Assert.That(bytes.Length, Is.GreaterThan(44));
+                Assert.That(BitConverter.ToInt16(bytes, 34), Is.EqualTo(8));
+            }
+            finally
+            {
+                if (clip != null)
+                {
+                    UnityEngine.Object.DestroyImmediate(clip);
+                }
+
+                if (Directory.Exists(root))
+                {
+                    Directory.Delete(root, true);
+                }
+            }
+        }
+    }
+}

--- a/Packages/com.sunmax.trusedison/Tests/Editor/GameAudioAudioClipConversionServiceTests.cs.meta
+++ b/Packages/com.sunmax.trusedison/Tests/Editor/GameAudioAudioClipConversionServiceTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 04a2ab8eaad743398132d8fff9926d24

--- a/Packages/com.sunmax.trusedison/Tests/Editor/GameAudioExportUtilityTests.cs
+++ b/Packages/com.sunmax.trusedison/Tests/Editor/GameAudioExportUtilityTests.cs
@@ -106,6 +106,46 @@ namespace TorusEdison.Editor.Tests
         }
 
         [Test]
+        public void EncodePcm8_WritesExpectedWaveHeader()
+        {
+            byte[] wavBytes = GameAudioWavEncoder.EncodePcm8(new[] { -1.0f, 0.0f, 1.0f, 0.5f }, 22050, 1);
+
+            using var stream = new MemoryStream(wavBytes);
+            using var reader = new BinaryReader(stream, Encoding.ASCII);
+
+            string riff = new string(reader.ReadChars(4));
+            int riffChunkSize = reader.ReadInt32();
+            string wave = new string(reader.ReadChars(4));
+            string fmt = new string(reader.ReadChars(4));
+            int fmtChunkSize = reader.ReadInt32();
+            short audioFormat = reader.ReadInt16();
+            short channelCount = reader.ReadInt16();
+            int sampleRate = reader.ReadInt32();
+            int byteRate = reader.ReadInt32();
+            short blockAlign = reader.ReadInt16();
+            short bitsPerSample = reader.ReadInt16();
+            string data = new string(reader.ReadChars(4));
+            int dataLength = reader.ReadInt32();
+
+            Assert.That(riff, Is.EqualTo("RIFF"));
+            Assert.That(riffChunkSize, Is.EqualTo(wavBytes.Length - 8));
+            Assert.That(wave, Is.EqualTo("WAVE"));
+            Assert.That(fmt, Is.EqualTo("fmt "));
+            Assert.That(fmtChunkSize, Is.EqualTo(16));
+            Assert.That(audioFormat, Is.EqualTo(1));
+            Assert.That(channelCount, Is.EqualTo(1));
+            Assert.That(sampleRate, Is.EqualTo(22050));
+            Assert.That(byteRate, Is.EqualTo(22050));
+            Assert.That(blockAlign, Is.EqualTo(1));
+            Assert.That(bitsPerSample, Is.EqualTo(8));
+            Assert.That(data, Is.EqualTo("data"));
+            Assert.That(dataLength, Is.EqualTo(4));
+
+            byte[] payload = reader.ReadBytes(dataLength);
+            Assert.That(payload, Is.EqualTo(new byte[] { 0, 128, 255, 191 }));
+        }
+
+        [Test]
         public void Export_WritesWaveFileToDisk()
         {
             string root = Path.Combine(Path.GetTempPath(), "TorusEdisonTests", Path.GetRandomFileName());


### PR DESCRIPTION
## Summary
- add an Export-page workflow that converts imported Unity `AudioClip` assets to 8-bit PCM WAV
- add conversion service and test coverage for 8-bit WAV encoding and AudioClip conversion output
- update the English and Japanese manuals plus changelog to document the new conversion flow and its scope boundary

## Validation
- Unity 6000.4.0f1 batch compile on a temp project copy
- Unity 6000.4.0f1 targeted EditMode tests for `GameAudioExportUtilityTests` and `GameAudioAudioClipConversionServiceTests` on a temp project copy

Closes #55