### PR TITLE
Generate conversion projects for 8-bit exports

### DIFF
--- a/Packages/com.sunmax.trusedison/CHANGELOG.md
+++ b/Packages/com.sunmax.trusedison/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - added imported `AudioClip` to 8-bit PCM WAV conversion in the Export page
+- added automatic generation of a conversion `.gats.json` project alongside 8-bit WAV export
 - added 8-bit WAV encoder coverage and audio-clip conversion tests
 
 ## 0.1.1

--- a/Packages/com.sunmax.trusedison/Documentation~/Manual.ja.md
+++ b/Packages/com.sunmax.trusedison/Documentation~/Manual.ja.md
@@ -81,6 +81,7 @@
 
 - `Export WAV`
 - Unity に取り込んだ `AudioClip` の 8-bit WAV 変換
+- 変換した WAV と同じフォルダへの変換用 `.gats.json` 自動生成
 - `Open Export Folder`
 - 共通既定フォルダ設定
 - プロジェクト上書きフォルダ設定
@@ -157,6 +158,7 @@ Export 画面には、Unity に取り込んだ `AudioClip` アセットを 8-bit
 - 変換後サンプルレートを指定
 - `Preserve Source` / `Mono` / `Stereo` を選択
 - 8-bit PCM `.wav` として書き出し
+- 同じフォルダへ変換用 `.gats.json` を自動生成
 
 この機能は、すでに Unity へ取り込んだ音声を変換するためのものです。YouTube など外部サービスから音源を取得する機能は含みません。
 

--- a/Packages/com.sunmax.trusedison/Documentation~/Manual.md
+++ b/Packages/com.sunmax.trusedison/Documentation~/Manual.md
@@ -80,6 +80,7 @@ Available controls:
 
 - `Export WAV`
 - imported `AudioClip` to 8-bit WAV conversion
+- automatic generation of a conversion-focused `.gats.json` project next to the converted WAV
 - `Open Export Folder`
 - common default folder
 - project override folder
@@ -147,6 +148,7 @@ The Export page also includes a conversion flow for imported `AudioClip` assets.
 - choose the target sample rate
 - choose `Preserve Source`, `Mono`, or `Stereo`
 - export as 8-bit PCM `.wav`
+- automatically generate a conversion `.gats.json` project in the same folder
 
 This feature converts audio that you already brought into Unity. It does not download or extract audio from YouTube or other external services.
 

--- a/Packages/com.sunmax.trusedison/Editor/Audio/GameAudioAudioClipConversionExportResult.cs
+++ b/Packages/com.sunmax.trusedison/Editor/Audio/GameAudioAudioClipConversionExportResult.cs
@@ -1,0 +1,15 @@
+namespace TorusEdison.Editor.Audio
+{
+    internal sealed class GameAudioAudioClipConversionExportResult
+    {
+        public GameAudioAudioClipConversionExportResult(string waveFilePath, string projectFilePath)
+        {
+            WaveFilePath = waveFilePath ?? string.Empty;
+            ProjectFilePath = projectFilePath ?? string.Empty;
+        }
+
+        public string WaveFilePath { get; }
+
+        public string ProjectFilePath { get; }
+    }
+}

--- a/Packages/com.sunmax.trusedison/Editor/Audio/GameAudioAudioClipConversionExportResult.cs.meta
+++ b/Packages/com.sunmax.trusedison/Editor/Audio/GameAudioAudioClipConversionExportResult.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 67bb71c7f218499ca52ee8af0cac2781
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.sunmax.trusedison/Editor/Audio/GameAudioAudioClipConversionService.cs
+++ b/Packages/com.sunmax.trusedison/Editor/Audio/GameAudioAudioClipConversionService.cs
@@ -1,13 +1,19 @@
 using System;
 using System.IO;
+using TorusEdison.Editor.Application;
+using TorusEdison.Editor.Domain;
+using TorusEdison.Editor.Persistence;
 using TorusEdison.Editor.Utilities;
+using UnityEditor;
 using UnityEngine;
 
 namespace TorusEdison.Editor.Audio
 {
     internal sealed class GameAudioAudioClipConversionService
     {
-        public string ExportAsPcm8(
+        private readonly GameAudioProjectSerializer _projectSerializer = new GameAudioProjectSerializer();
+
+        public GameAudioAudioClipConversionExportResult ExportAsPcm8(
             AudioClip sourceClip,
             string exportDirectory,
             string outputName,
@@ -63,8 +69,22 @@ namespace TorusEdison.Editor.Audio
             Directory.CreateDirectory(directoryPath);
             byte[] wavBytes = GameAudioWavEncoder.EncodePcm8(convertedSamples, resolvedSampleRate, outputChannelCount);
             File.WriteAllBytes(filePath, wavBytes);
-            GameAudioDiagnosticLogger.Verbose("Conversion", $"Encoded 8-bit WAV {filePath} ({resolvedSampleRate} Hz / {outputChannelCount} ch).");
-            return filePath;
+            string waveFileName = Path.GetFileName(filePath);
+
+            GameAudioProject conversionProject = CreateConversionProject(
+                sourceClip,
+                outputName,
+                resolvedSampleRate,
+                channelMode,
+                outputChannelCount,
+                waveFileName);
+
+            string projectFilePath = GameAudioExportUtility.BuildProjectFilePath(exportDirectory, outputName);
+            _projectSerializer.SaveToFile(projectFilePath, conversionProject);
+            GameAudioDiagnosticLogger.Verbose(
+                "Conversion",
+                $"Encoded 8-bit WAV {filePath} ({resolvedSampleRate} Hz / {outputChannelCount} ch) and generated conversion project {projectFilePath}.");
+            return new GameAudioAudioClipConversionExportResult(filePath, projectFilePath);
         }
 
         internal static float[] ConvertSamples(
@@ -199,6 +219,71 @@ namespace TorusEdison.Editor.Audio
             }
 
             return total / count;
+        }
+
+        private static GameAudioProject CreateConversionProject(
+            AudioClip sourceClip,
+            string outputName,
+            int targetSampleRate,
+            GameAudioConversionChannelMode channelMode,
+            int outputChannelCount,
+            string outputWaveFileName)
+        {
+            string projectName = ResolveProjectName(sourceClip, outputName);
+            var project = GameAudioProjectFactory.CreateDefaultProject(
+                targetSampleRate,
+                outputChannelCount == 1 ? GameAudioChannelMode.Mono : GameAudioChannelMode.Stereo);
+
+            project.Name = projectName;
+            project.TotalBars = CalculateTotalBars(sourceClip.length, project.Bpm, project.TimeSignature?.Numerator ?? 4, project.TimeSignature?.Denominator ?? 4);
+            if (project.Tracks.Count > 0)
+            {
+                project.Tracks[0].Name = "Imported Audio";
+            }
+
+            string assetPath = AssetDatabase.GetAssetPath(sourceClip);
+            project.ImportedAudioConversion = new GameAudioImportedAudioConversion
+            {
+                SourceClipName = sourceClip.name ?? string.Empty,
+                SourceAssetPath = string.IsNullOrWhiteSpace(assetPath) ? "(not imported)" : assetPath,
+                SourceSampleRate = sourceClip.frequency,
+                SourceChannelCount = sourceClip.channels,
+                SourceDurationSeconds = sourceClip.length,
+                TargetSampleRate = targetSampleRate,
+                TargetChannelMode = channelMode.ToString(),
+                OutputChannelCount = outputChannelCount,
+                OutputWaveFileName = outputWaveFileName ?? string.Empty
+            };
+
+            return project;
+        }
+
+        private static string ResolveProjectName(AudioClip sourceClip, string outputName)
+        {
+            if (!string.IsNullOrWhiteSpace(outputName))
+            {
+                return outputName.Trim();
+            }
+
+            if (sourceClip != null && !string.IsNullOrWhiteSpace(sourceClip.name))
+            {
+                return $"{sourceClip.name}_8bit";
+            }
+
+            return "Converted8Bit";
+        }
+
+        private static int CalculateTotalBars(float durationSeconds, int bpm, int numerator, int denominator)
+        {
+            if (durationSeconds <= 0.0f || bpm <= 0)
+            {
+                return GameAudioToolInfo.DefaultTotalBars;
+            }
+
+            float beatsPerBar = Mathf.Max(1.0f, numerator * (4.0f / Mathf.Max(1, denominator)));
+            double totalBeats = durationSeconds * bpm / 60.0;
+            int totalBars = Math.Max(1, (int)Math.Ceiling(totalBeats / beatsPerBar));
+            return Math.Clamp(totalBars, 1, GameAudioToolInfo.MaxTotalBars);
         }
     }
 }

--- a/Packages/com.sunmax.trusedison/Editor/Domain/GameAudioImportedAudioConversion.cs
+++ b/Packages/com.sunmax.trusedison/Editor/Domain/GameAudioImportedAudioConversion.cs
@@ -1,0 +1,23 @@
+namespace TorusEdison.Editor.Domain
+{
+    public sealed class GameAudioImportedAudioConversion
+    {
+        public string SourceClipName { get; set; } = string.Empty;
+
+        public string SourceAssetPath { get; set; } = string.Empty;
+
+        public int SourceSampleRate { get; set; }
+
+        public int SourceChannelCount { get; set; }
+
+        public float SourceDurationSeconds { get; set; }
+
+        public int TargetSampleRate { get; set; }
+
+        public string TargetChannelMode { get; set; } = "Preserve";
+
+        public int OutputChannelCount { get; set; }
+
+        public string OutputWaveFileName { get; set; } = string.Empty;
+    }
+}

--- a/Packages/com.sunmax.trusedison/Editor/Domain/GameAudioImportedAudioConversion.cs.meta
+++ b/Packages/com.sunmax.trusedison/Editor/Domain/GameAudioImportedAudioConversion.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c9653ea919ce4d37a75f5f6138d77cd9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.sunmax.trusedison/Editor/Domain/GameAudioProject.cs
+++ b/Packages/com.sunmax.trusedison/Editor/Domain/GameAudioProject.cs
@@ -22,6 +22,8 @@ namespace TorusEdison.Editor.Domain
 
         public bool LoopPlayback { get; set; }
 
+        public GameAudioImportedAudioConversion ImportedAudioConversion { get; set; }
+
         public List<GameAudioTrack> Tracks { get; set; } = new List<GameAudioTrack>();
     }
 }

--- a/Packages/com.sunmax.trusedison/Editor/Persistence/GameAudioPersistenceDtos.cs
+++ b/Packages/com.sunmax.trusedison/Editor/Persistence/GameAudioPersistenceDtos.cs
@@ -22,7 +22,22 @@ namespace TorusEdison.Editor.Persistence
         public string channelMode;
         public float masterGainDb;
         public bool loopPlayback;
+        public GameAudioImportedAudioConversionDto importedAudioConversion;
         public GameAudioTrackDto[] tracks;
+    }
+
+    [Serializable]
+    internal sealed class GameAudioImportedAudioConversionDto
+    {
+        public string sourceClipName;
+        public string sourceAssetPath;
+        public int sourceSampleRate;
+        public int sourceChannelCount;
+        public float sourceDurationSeconds;
+        public int targetSampleRate;
+        public string targetChannelMode;
+        public int outputChannelCount;
+        public string outputWaveFileName;
     }
 
     [Serializable]

--- a/Packages/com.sunmax.trusedison/Editor/Persistence/GameAudioProjectSchemaValidator.cs
+++ b/Packages/com.sunmax.trusedison/Editor/Persistence/GameAudioProjectSchemaValidator.cs
@@ -32,12 +32,31 @@ namespace TorusEdison.Editor.Persistence
             RequireString(node, path, "channelMode");
             RequireNumber(node, path, "masterGainDb");
             RequireBoolean(node, path, "loopPlayback");
+            if (TryGetProperty(node, "importedAudioConversion", out GameAudioJsonNode importedAudioConversion)
+                && importedAudioConversion.Kind != GameAudioJsonKind.Null)
+            {
+                ValidateImportedAudioConversion(importedAudioConversion, $"{path}.importedAudioConversion");
+            }
 
             GameAudioJsonNode tracks = RequireArrayProperty(node, path, "tracks");
             for (int index = 0; index < tracks.Items.Count; index++)
             {
                 ValidateTrack(tracks.Items[index], $"{path}.tracks[{index}]");
             }
+        }
+
+        private static void ValidateImportedAudioConversion(GameAudioJsonNode node, string path)
+        {
+            RequireObject(node, path);
+            RequireString(node, path, "sourceClipName");
+            RequireString(node, path, "sourceAssetPath");
+            RequireNumber(node, path, "sourceSampleRate");
+            RequireNumber(node, path, "sourceChannelCount");
+            RequireNumber(node, path, "sourceDurationSeconds");
+            RequireNumber(node, path, "targetSampleRate");
+            RequireString(node, path, "targetChannelMode");
+            RequireNumber(node, path, "outputChannelCount");
+            RequireString(node, path, "outputWaveFileName");
         }
 
         private static void ValidateTrack(GameAudioJsonNode node, string path)

--- a/Packages/com.sunmax.trusedison/Editor/Persistence/GameAudioProjectSerializer.cs
+++ b/Packages/com.sunmax.trusedison/Editor/Persistence/GameAudioProjectSerializer.cs
@@ -138,9 +138,26 @@ namespace TorusEdison.Editor.Persistence
                 channelMode = project.ChannelMode.ToString(),
                 masterGainDb = GameAudioValidationUtility.ClampFloat(project.MasterGainDb, -24.0f, 6.0f),
                 loopPlayback = project.LoopPlayback,
+                importedAudioConversion = project.ImportedAudioConversion == null ? null : ToDto(project.ImportedAudioConversion),
                 tracks = (project.Tracks ?? new List<GameAudioTrack>())
                     .Select(ToDto)
                     .ToArray()
+            };
+        }
+
+        private static GameAudioImportedAudioConversionDto ToDto(GameAudioImportedAudioConversion conversion)
+        {
+            return new GameAudioImportedAudioConversionDto
+            {
+                sourceClipName = conversion.SourceClipName ?? string.Empty,
+                sourceAssetPath = conversion.SourceAssetPath ?? string.Empty,
+                sourceSampleRate = Math.Max(0, conversion.SourceSampleRate),
+                sourceChannelCount = Math.Max(0, conversion.SourceChannelCount),
+                sourceDurationSeconds = Math.Max(0.0f, conversion.SourceDurationSeconds),
+                targetSampleRate = Math.Max(0, conversion.TargetSampleRate),
+                targetChannelMode = string.IsNullOrWhiteSpace(conversion.TargetChannelMode) ? "Preserve" : conversion.TargetChannelMode,
+                outputChannelCount = Math.Max(0, conversion.OutputChannelCount),
+                outputWaveFileName = conversion.OutputWaveFileName ?? string.Empty
             };
         }
 
@@ -233,7 +250,8 @@ namespace TorusEdison.Editor.Persistence
                 SampleRate = ReadSampleRate(dto.sampleRate, warnings, "project.sampleRate"),
                 ChannelMode = ReadChannelMode(dto.channelMode, GameAudioChannelMode.Stereo, warnings, "project.channelMode"),
                 MasterGainDb = ReadClamped(dto.masterGainDb, -24.0f, 6.0f, 0.0f, warnings, "project.masterGainDb"),
-                LoopPlayback = dto.loopPlayback
+                LoopPlayback = dto.loopPlayback,
+                ImportedAudioConversion = ReadImportedAudioConversion(dto.importedAudioConversion, warnings)
             };
 
             for (int index = 0; index < trackDtos.Length; index++)
@@ -243,6 +261,27 @@ namespace TorusEdison.Editor.Persistence
             }
 
             return project;
+        }
+
+        private static GameAudioImportedAudioConversion ReadImportedAudioConversion(GameAudioImportedAudioConversionDto dto, List<string> warnings)
+        {
+            if (dto == null)
+            {
+                return null;
+            }
+
+            return new GameAudioImportedAudioConversion
+            {
+                SourceClipName = ReadRequiredText(dto.sourceClipName, string.Empty, warnings, "project.importedAudioConversion.sourceClipName"),
+                SourceAssetPath = ReadRequiredText(dto.sourceAssetPath, string.Empty, warnings, "project.importedAudioConversion.sourceAssetPath"),
+                SourceSampleRate = ReadPositive(dto.sourceSampleRate, 0, warnings, "project.importedAudioConversion.sourceSampleRate"),
+                SourceChannelCount = ReadPositive(dto.sourceChannelCount, 0, warnings, "project.importedAudioConversion.sourceChannelCount"),
+                SourceDurationSeconds = ReadClamped(dto.sourceDurationSeconds, 0.0f, 36000.0f, 0.0f, warnings, "project.importedAudioConversion.sourceDurationSeconds"),
+                TargetSampleRate = ReadPositive(dto.targetSampleRate, 0, warnings, "project.importedAudioConversion.targetSampleRate"),
+                TargetChannelMode = ReadRequiredText(dto.targetChannelMode, "Preserve", warnings, "project.importedAudioConversion.targetChannelMode"),
+                OutputChannelCount = ReadPositive(dto.outputChannelCount, 0, warnings, "project.importedAudioConversion.outputChannelCount"),
+                OutputWaveFileName = ReadRequiredText(dto.outputWaveFileName, string.Empty, warnings, "project.importedAudioConversion.outputWaveFileName")
+            };
         }
 
         private static GameAudioTrack FromDto(GameAudioTrackDto dto, int trackIndex, List<string> warnings)

--- a/Packages/com.sunmax.trusedison/Editor/Utilities/GameAudioExportUtility.cs
+++ b/Packages/com.sunmax.trusedison/Editor/Utilities/GameAudioExportUtility.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using TorusEdison.Editor.Persistence;
 
 namespace TorusEdison.Editor.Utilities
 {
@@ -78,6 +79,22 @@ namespace TorusEdison.Editor.Utilities
             }
 
             return Path.Combine(exportDirectory, NormalizeWaveFileName(projectName));
+        }
+
+        public static string BuildProjectFilePath(string exportDirectory, string projectName)
+        {
+            if (string.IsNullOrWhiteSpace(exportDirectory))
+            {
+                throw new ArgumentException("Export directory is required.", nameof(exportDirectory));
+            }
+
+            string sanitizedName = GameAudioValidationUtility.SanitizeExportFileName(projectName);
+            if (string.IsNullOrWhiteSpace(sanitizedName))
+            {
+                sanitizedName = "GameAudio";
+            }
+
+            return GameAudioProjectFileUtility.NormalizeSavePath(Path.Combine(exportDirectory, sanitizedName));
         }
 
         public static bool ShouldRefreshAssetDatabase(string filePath, string projectRoot)

--- a/Packages/com.sunmax.trusedison/Editor/Windows/GameAudioToolWindow.cs
+++ b/Packages/com.sunmax.trusedison/Editor/Windows/GameAudioToolWindow.cs
@@ -51,6 +51,7 @@ namespace TorusEdison.Editor.Windows
         private List<string> _loadWarnings = new List<string>();
         private string _lastExportedPath = string.Empty;
         private string _lastConverted8BitPath = string.Empty;
+        private string _lastConverted8BitProjectPath = string.Empty;
         private IVisualElementScheduledItem _previewTicker;
         private TimelineDragState _timelineDragState;
         private Vector2 _timelineScrollPosition;
@@ -85,6 +86,7 @@ namespace TorusEdison.Editor.Windows
         private PopupField<int> _conversionSampleRateField;
         private PopupField<GameAudioConversionChannelMode> _conversionChannelModeField;
         private Label _conversionLastResultValue;
+        private Label _conversionLastProjectValue;
         private IntegerField _toolbarBpmField;
         private PopupField<string> _toolbarGridField;
         private Toggle _toolbarLoopToggle;
@@ -545,6 +547,7 @@ namespace TorusEdison.Editor.Windows
             panel.Add(conversionActionRow);
 
             _conversionLastResultValue = AddKeyValue(panel, T("export.convert8Bit.lastExport", "Last 8-bit Export"));
+            _conversionLastProjectValue = AddKeyValue(panel, T("export.convert8Bit.lastProject", "Last Conversion Project"));
 
             return panel;
         }
@@ -2151,16 +2154,18 @@ namespace TorusEdison.Editor.Windows
             {
                 string exportDirectory = GetResolvedExportDirectory();
                 string outputName = GetResolvedConversionOutputName();
-                string exportPath = _audioClipConversionService.ExportAsPcm8(
+                GameAudioAudioClipConversionExportResult exportResult = _audioClipConversionService.ExportAsPcm8(
                     _conversionSourceClip,
                     exportDirectory,
                     outputName,
                     _conversionTargetSampleRate,
                     _conversionChannelMode);
-                _lastConverted8BitPath = exportPath;
+                _lastConverted8BitPath = exportResult.WaveFilePath;
+                _lastConverted8BitProjectPath = exportResult.ProjectFilePath;
 
                 bool shouldRefresh = (_projectConfig?.AutoRefreshAfterExport ?? true)
-                    && GameAudioExportUtility.ShouldRefreshAssetDatabase(exportPath, GetProjectRootPath());
+                    && (GameAudioExportUtility.ShouldRefreshAssetDatabase(exportResult.WaveFilePath, GetProjectRootPath())
+                        || GameAudioExportUtility.ShouldRefreshAssetDatabase(exportResult.ProjectFilePath, GetProjectRootPath()));
                 if (shouldRefresh)
                 {
                     AssetDatabase.Refresh();
@@ -2168,10 +2173,10 @@ namespace TorusEdison.Editor.Windows
 
                 GameAudioDiagnosticLogger.Info(
                     "Conversion",
-                    $"Exported 8-bit WAV to {exportPath}. AutoRefresh={shouldRefresh}. Source={_conversionSourceClip.name}; SampleRate={_conversionTargetSampleRate}; ChannelMode={_conversionChannelMode}.");
+                    $"Exported 8-bit WAV to {exportResult.WaveFilePath} and conversion project to {exportResult.ProjectFilePath}. AutoRefresh={shouldRefresh}. Source={_conversionSourceClip.name}; SampleRate={_conversionTargetSampleRate}; ChannelMode={_conversionChannelMode}.");
                 ShowNotification(new GUIContent(shouldRefresh
-                    ? T("status.convert8BitExportedAndRefreshed", "8-bit WAV exported and assets refreshed.")
-                    : T("status.convert8BitExported", "8-bit WAV exported.")));
+                    ? T("status.convert8BitExportedAndRefreshed", "8-bit WAV and conversion project exported, then assets refreshed.")
+                    : T("status.convert8BitExported", "8-bit WAV and conversion project exported.")));
                 RefreshView();
             }
             catch (Exception exception)
@@ -3309,6 +3314,12 @@ namespace TorusEdison.Editor.Windows
             _conversionLastResultValue.text = string.IsNullOrWhiteSpace(_lastConverted8BitPath)
                 ? T("status.notExported", "(not exported)")
                 : _lastConverted8BitPath;
+            if (_conversionLastProjectValue != null)
+            {
+                _conversionLastProjectValue.text = string.IsNullOrWhiteSpace(_lastConverted8BitProjectPath)
+                    ? T("status.notExported", "(not exported)")
+                    : _lastConverted8BitProjectPath;
+            }
 
             if (_undoButton != null)
             {

--- a/Packages/com.sunmax.trusedison/Tests/Editor/GameAudioAudioClipConversionServiceTests.cs
+++ b/Packages/com.sunmax.trusedison/Tests/Editor/GameAudioAudioClipConversionServiceTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using NUnit.Framework;
 using TorusEdison.Editor.Audio;
+using TorusEdison.Editor.Persistence;
 using UnityEngine;
 
 namespace TorusEdison.Editor.Tests
@@ -49,7 +50,7 @@ namespace TorusEdison.Editor.Tests
         }
 
         [Test]
-        public void ExportAsPcm8_WritesWaveFileToDisk()
+        public void ExportAsPcm8_WritesWaveAndGeneratedProjectFilesToDisk()
         {
             string root = Path.Combine(Path.GetTempPath(), "TorusEdisonTests", Path.GetRandomFileName());
             AudioClip clip = null;
@@ -60,19 +61,30 @@ namespace TorusEdison.Editor.Tests
                 clip.SetData(new[] { -1.0f, 0.0f, 1.0f, 0.5f }, 0);
 
                 var service = new GameAudioAudioClipConversionService();
-                string filePath = service.ExportAsPcm8(
+                GameAudioAudioClipConversionExportResult exportResult = service.ExportAsPcm8(
                     clip,
                     root,
                     "Converted:Clip",
                     22050,
                     GameAudioConversionChannelMode.Preserve);
 
-                Assert.That(File.Exists(filePath), Is.True);
-                Assert.That(Path.GetFileName(filePath), Is.EqualTo("Converted_Clip.wav"));
+                Assert.That(File.Exists(exportResult.WaveFilePath), Is.True);
+                Assert.That(Path.GetFileName(exportResult.WaveFilePath), Is.EqualTo("Converted_Clip.wav"));
+                Assert.That(File.Exists(exportResult.ProjectFilePath), Is.True);
+                Assert.That(Path.GetFileName(exportResult.ProjectFilePath), Is.EqualTo("Converted_Clip.gats.json"));
 
-                byte[] bytes = File.ReadAllBytes(filePath);
+                byte[] bytes = File.ReadAllBytes(exportResult.WaveFilePath);
                 Assert.That(bytes.Length, Is.GreaterThan(44));
                 Assert.That(BitConverter.ToInt16(bytes, 34), Is.EqualTo(8));
+
+                var serializer = new GameAudioProjectSerializer();
+                GameAudioProjectLoadResult projectResult = serializer.LoadFromFile(exportResult.ProjectFilePath);
+                Assert.That(projectResult.Project.Name, Is.EqualTo("Converted:Clip"));
+                Assert.That(projectResult.Project.SampleRate, Is.EqualTo(22050));
+                Assert.That(projectResult.Project.ImportedAudioConversion, Is.Not.Null);
+                Assert.That(projectResult.Project.ImportedAudioConversion.SourceClipName, Is.EqualTo("source-clip"));
+                Assert.That(projectResult.Project.ImportedAudioConversion.TargetChannelMode, Is.EqualTo("Preserve"));
+                Assert.That(projectResult.Project.ImportedAudioConversion.OutputWaveFileName, Is.EqualTo("Converted_Clip.wav"));
             }
             finally
             {

--- a/Packages/com.sunmax.trusedison/Tests/Editor/GameAudioExportUtilityTests.cs
+++ b/Packages/com.sunmax.trusedison/Tests/Editor/GameAudioExportUtilityTests.cs
@@ -38,6 +38,14 @@ namespace TorusEdison.Editor.Tests
         }
 
         [Test]
+        public void BuildProjectFilePath_SanitizesNameAndAppendsSessionExtension()
+        {
+            string path = GameAudioExportUtility.BuildProjectFilePath("D:/Exports", "Boss:SE?");
+
+            Assert.That(path.Replace('\\', '/'), Is.EqualTo("D:/Exports/Boss_SE_.gats.json"));
+        }
+
+        [Test]
         public void NormalizeStoredExportDirectory_ConvertsProjectSubfolderToRelativePath()
         {
             string stored = GameAudioExportUtility.NormalizeStoredExportDirectory("D:/ProjectRoot/Assets/Exports/Audio", "D:/ProjectRoot");

--- a/Packages/com.sunmax.trusedison/Tests/Editor/GameAudioProjectSerializerTests.cs
+++ b/Packages/com.sunmax.trusedison/Tests/Editor/GameAudioProjectSerializerTests.cs
@@ -40,6 +40,36 @@ namespace TorusEdison.Editor.Tests
         }
 
         [Test]
+        public void SerializeAndDeserialize_RoundTripsImportedAudioConversionMetadata()
+        {
+            var serializer = new GameAudioProjectSerializer();
+            GameAudioProject project = GameAudioProjectFactory.CreateDefaultProject();
+            project.Name = "ImportedConversion";
+            project.ImportedAudioConversion = new GameAudioImportedAudioConversion
+            {
+                SourceClipName = "voice-source",
+                SourceAssetPath = "Assets/Audio/voice-source.wav",
+                SourceSampleRate = 44100,
+                SourceChannelCount = 2,
+                SourceDurationSeconds = 3.5f,
+                TargetSampleRate = 11025,
+                TargetChannelMode = "Mono",
+                OutputChannelCount = 1,
+                OutputWaveFileName = "voice-source_8bit.wav"
+            };
+
+            string json = serializer.Serialize(project);
+            GameAudioProjectLoadResult result = serializer.Deserialize(json);
+
+            Assert.That(result.Project.ImportedAudioConversion, Is.Not.Null);
+            Assert.That(result.Project.ImportedAudioConversion.SourceClipName, Is.EqualTo("voice-source"));
+            Assert.That(result.Project.ImportedAudioConversion.SourceAssetPath, Is.EqualTo("Assets/Audio/voice-source.wav"));
+            Assert.That(result.Project.ImportedAudioConversion.TargetSampleRate, Is.EqualTo(11025));
+            Assert.That(result.Project.ImportedAudioConversion.TargetChannelMode, Is.EqualTo("Mono"));
+            Assert.That(result.Project.ImportedAudioConversion.OutputWaveFileName, Is.EqualTo("voice-source_8bit.wav"));
+        }
+
+        [Test]
         public void Deserialize_RejectsUnsupportedFormatVersion()
         {
             const string json = @"{


### PR DESCRIPTION
## Summary
- generate a new conversion-focused `.gats.json` project alongside imported `AudioClip` 8-bit WAV export
- persist imported-audio conversion metadata in the exported project for traceability
- update the Export UI, serializer coverage, manuals, and changelog for the paired export flow

## Validation
- Unity 6000.4.0f1 batch compile on a temp project copy
- Unity 6000.4.0f1 targeted EditMode tests for conversion, export utility, and project serializer on a temp project copy

Closes #57