### PR TITLE
Make the timeline help window modeless

### DIFF
--- a/Packages/com.sunmax.trusedison/Editor/Windows/GameAudioTimelineHelpWindow.cs
+++ b/Packages/com.sunmax.trusedison/Editor/Windows/GameAudioTimelineHelpWindow.cs
@@ -15,13 +15,21 @@ namespace TorusEdison.Editor.Windows
 
         public static void Open(GameAudioDisplayLanguage displayLanguage, string hintText)
         {
-            var window = CreateInstance<GameAudioTimelineHelpWindow>();
+            GameAudioTimelineHelpWindow window = HasOpenInstances<GameAudioTimelineHelpWindow>()
+                ? GetWindow<GameAudioTimelineHelpWindow>()
+                : CreateInstance<GameAudioTimelineHelpWindow>();
             window._displayLanguage = displayLanguage;
             window._hintText = hintText ?? string.Empty;
             window.titleContent = new GUIContent(GameAudioLocalization.Get(displayLanguage, "timeline.help.title", "Timeline Editing Help"));
             window.minSize = new Vector2(440.0f, 300.0f);
             window.maxSize = new Vector2(560.0f, 420.0f);
-            window.ShowModalUtility();
+            if (window.rootVisualElement.childCount > 0)
+            {
+                window.CreateGUI();
+            }
+
+            window.ShowUtility();
+            window.Focus();
         }
 
         private void CreateGUI()
@@ -39,7 +47,7 @@ namespace TorusEdison.Editor.Windows
             titleLabel.style.marginBottom = 8.0f;
             rootVisualElement.Add(titleLabel);
 
-            var summaryLabel = new Label(T("timeline.help.summary", "Open this when you need a quick reminder of the current timeline mouse and keyboard shortcuts."));
+            var summaryLabel = new Label(T("timeline.help.summary", "Leave this window open when you need a quick reminder of the current timeline mouse and keyboard shortcuts while continuing to edit."));
             summaryLabel.style.whiteSpace = WhiteSpace.Normal;
             summaryLabel.style.marginBottom = 12.0f;
             rootVisualElement.Add(summaryLabel);


### PR DESCRIPTION
## Summary
- switch the timeline help window from modal utility to modeless utility behavior
- reuse the same help window instance when reopening from the Edit tab
- refresh the help copy to reflect that editing can continue while the window stays open

## Validation
- Unity 6000.4.0f1 batch compile on a temp project copy

Closes #62