### PR TITLE
Skip prompts for untouched empty projects

### DIFF
--- a/Packages/com.sunmax.trusedison/Editor/Windows/GameAudioToolWindow.cs
+++ b/Packages/com.sunmax.trusedison/Editor/Windows/GameAudioToolWindow.cs
@@ -123,7 +123,7 @@ namespace TorusEdison.Editor.Windows
 
             if (_project == null)
             {
-                BindProject(CreateConfiguredProject(), true, string.Empty, Array.Empty<string>());
+                BindProject(CreateConfiguredProject(), false, string.Empty, Array.Empty<string>());
             }
 
             rootVisualElement.Clear();
@@ -1455,7 +1455,7 @@ namespace TorusEdison.Editor.Windows
                 return;
             }
 
-            BindProject(CreateConfiguredProject(), true, string.Empty, Array.Empty<string>());
+            BindProject(CreateConfiguredProject(), false, string.Empty, Array.Empty<string>());
             RefreshView();
         }
 


### PR DESCRIPTION
## Summary
- treat the initial empty configured project as unedited when the window first opens
- treat a newly created empty project as unedited until the user actually changes it
- avoid showing discard confirmation for untouched empty project shells

## Validation
- Unity 6000.4.0f1 batch compile on a temp project copy

Closes #64