### PR TITLE
Fix delayed settings rebuild after language change

### DIFF
--- a/Packages/com.sunmax.trusedison/Editor/Windows/GameAudioToolWindow.cs
+++ b/Packages/com.sunmax.trusedison/Editor/Windows/GameAudioToolWindow.cs
@@ -3494,20 +3494,23 @@ namespace TorusEdison.Editor.Windows
             }
 
             _pendingUiRebuild = true;
+            EditorApplication.delayCall -= RebuildUiAfterDelay;
+            EditorApplication.delayCall += RebuildUiAfterDelay;
+        }
 
-            if (rootVisualElement != null)
+        private void RebuildUiAfterDelay()
+        {
+            EditorApplication.delayCall -= RebuildUiAfterDelay;
+
+            if (this == null)
             {
-                rootVisualElement.schedule.Execute(() =>
-                {
-                    _pendingUiRebuild = false;
-                    CreateGUI();
-                });
-
                 return;
             }
 
             _pendingUiRebuild = false;
             CreateGUI();
+            rootVisualElement?.Focus();
+            Repaint();
         }
 
         private void OnRootKeyDown(KeyDownEvent evt)
@@ -3700,6 +3703,7 @@ namespace TorusEdison.Editor.Windows
 
         private void OnDisable()
         {
+            EditorApplication.delayCall -= RebuildUiAfterDelay;
             _previewTicker?.Pause();
             _previewTicker = null;
             _previewPlaybackService.Dispose();


### PR DESCRIPTION
## Summary
- move the language-triggered UI rebuild onto `EditorApplication.delayCall`
- avoid rebuilding the Settings page inside the active value-change event
- clear the pending rebuild flag only when the delayed rebuild actually runs

## Validation
- `git diff --check`
- Unity `6000.4.0f1` temp-copy batch compile

Closes #60