### PR TITLE
Fix inspector cache after language-driven UI rebuild

### DIFF
--- a/Packages/com.sunmax.trusedison/Editor/Windows/GameAudioToolWindow.cs
+++ b/Packages/com.sunmax.trusedison/Editor/Windows/GameAudioToolWindow.cs
@@ -139,6 +139,7 @@ namespace TorusEdison.Editor.Windows
             rootVisualElement.style.paddingBottom = 12;
             _workspaceTabButtons.Clear();
             _workspacePages.Clear();
+            _inspectorStateKey = string.Empty;
 
             rootVisualElement.Add(BuildToolbar());
             rootVisualElement.Add(BuildNavigationBar());
@@ -993,8 +994,9 @@ namespace TorusEdison.Editor.Windows
                 : string.Join(",", _selectedNoteIds.OrderBy(noteId => noteId, StringComparer.Ordinal));
             string nextStateKey = string.Format(
                 CultureInfo.InvariantCulture,
-                "{0}|{1}|{2}",
+                "{0}|{1}|{2}|{3}",
                 RuntimeHelpers.GetHashCode(project),
+                _displayLanguage,
                 _selectedTrackId,
                 selectionKey);
 


### PR DESCRIPTION
## Summary
- invalidate the inspector rebuild cache whenever `CreateGUI()` reconstructs the workspace
- include the active display language in the inspector state key
- keep the language-switch refresh from leaving rebuilt Settings containers empty

## Validation
- `git diff --check`
- Unity `6000.4.0f1` temp-copy batch compile

Closes #60