### PR TITLE
Clean obsolete warning sources

### DIFF
--- a/Packages/com.sunmax.trusedison/Editor/GameAudioTool.Editor.asmdef.meta
+++ b/Packages/com.sunmax.trusedison/Editor/GameAudioTool.Editor.asmdef.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: b2893ccc8e6831b4b92179238004f8bc
-AssemblyDefinitionImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Packages/com.sunmax.trusedison/Editor/Windows/GameAudioToolWindow.cs
+++ b/Packages/com.sunmax.trusedison/Editor/Windows/GameAudioToolWindow.cs
@@ -3594,8 +3594,8 @@ namespace TorusEdison.Editor.Windows
                 return;
             }
 
+            evt.StopImmediatePropagation();
             evt.StopPropagation();
-            evt.PreventDefault();
         }
 
         private string BuildPreviewBufferText(GameAudioPreviewState previewState)

--- a/Packages/com.sunmax.trusedison/Tests/Editor/GameAudioTool.Editor.Tests.asmdef.meta
+++ b/Packages/com.sunmax.trusedison/Tests/Editor/GameAudioTool.Editor.Tests.asmdef.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: ddc8e19e956e37742b79319fff367b11
-AssemblyDefinitionImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- delete the tracked orphan `.meta` files for the old `GameAudioTool.Editor*.asmdef` names
- replace the obsolete UIToolkit `PreventDefault()` call with supported propagation control
- keep the package warning cleanup isolated to the current Torus Edison asmdef layout

## Validation
- `git diff --check`
- Unity `6000.4.0f1` temp-copy batch compile

Closes #78